### PR TITLE
Refactor/internal style capabilities

### DIFF
--- a/apps/docs/src/app/pages/components/media-item.page.ts
+++ b/apps/docs/src/app/pages/components/media-item.page.ts
@@ -95,8 +95,8 @@ interface AlignDemo {
               nbSurface
               border="strong"
               layout="stack"
-              radius="base"
-              shadow="lifted"
+              radius="sm"
+              shadow="hard"
               clip
             >
               <div class="border-b-2 border-(--nb-border) bg-(--nb-accent) px-4 py-3 text-(--nb-accent-foreground)">
@@ -440,7 +440,7 @@ interface AlignDemo {
 export default class MediaItemPage {
   protected readonly importCode = `import { NbMediaItem, NbMediaItemTitle, NbSeparator, NbSurface } from '@ng-brutalism/ui';`;
 
-  protected readonly defaultExampleCode = `<div nbSurface border="strong" layout="stack" radius="base" shadow="lifted" clip>
+  protected readonly defaultExampleCode = `<div nbSurface border="strong" layout="stack" radius="sm" shadow="hard" clip>
   <div class="border-b-2 border-(--nb-border) bg-(--nb-accent) px-4 py-3 text-(--nb-accent-foreground)">
     <span class="font-heading text-2xl uppercase leading-none">Your Flight</span>
   </div>

--- a/apps/docs/src/app/pages/components/section.page.ts
+++ b/apps/docs/src/app/pages/components/section.page.ts
@@ -9,8 +9,8 @@ import {
   NbStack,
   NbSurface,
   type NbSectionAlign,
-  type NbSectionBorder,
-  type NbSectionBorderStyle,
+  type NbSectionDivider,
+  type NbSectionDividerStyle,
   type NbSectionLayout,
   type NbSectionPadding,
 } from '@ng-brutalism/ui';
@@ -24,14 +24,14 @@ interface SectionPaddingDemo {
   readonly label: string;
 }
 
-interface SectionBorderDemo {
-  readonly value: NbSectionBorder;
+interface SectionDividerDemo {
+  readonly value: NbSectionDivider;
   readonly label: string;
   readonly hint: string;
 }
 
-interface SectionBorderStyleDemo {
-  readonly value: NbSectionBorderStyle;
+interface SectionDividerStyleDemo {
+  readonly value: NbSectionDividerStyle;
   readonly label: string;
 }
 
@@ -105,7 +105,7 @@ interface SectionLayoutDemo {
           >
             <div
               nbSection
-              border="bottom"
+              divider="bottom"
               padding="lg"
               layout="between"
               align="center"
@@ -131,7 +131,7 @@ interface SectionLayoutDemo {
 
             <div
               nbSection
-              border="top"
+              divider="top"
               padding="lg"
               layout="between"
               align="center"
@@ -240,8 +240,8 @@ interface SectionLayoutDemo {
                   <div
                     nbSection
                     padding="md"
-                    border="all"
-                    [borderStyle]="style.value"
+                    divider="all"
+                    [dividerStyle]="style.value"
                   >
                     <div
                       class="grid h-12 place-items-center border-2 border-(--nb-border) bg-(--nb-lavender) px-3 font-mono text-xs font-black uppercase"
@@ -325,7 +325,7 @@ interface SectionLayoutDemo {
             <div
               nbSection
               padding="lg"
-              border="bottom"
+              divider="bottom"
               layout="between"
               align="center"
               class="bg-(--nb-cream)"
@@ -357,7 +357,7 @@ interface SectionLayoutDemo {
 
             <div
               nbSection
-              border="top"
+              divider="top"
               padding="lg"
               layout="between"
               align="center"
@@ -406,7 +406,7 @@ interface SectionLayoutDemo {
               </tr>
               <tr class="border-b-2 border-(--nb-border)">
                 <td class="border-r-2 border-(--nb-border) px-4 py-3 font-mono text-sm">
-                  border
+                  divider
                 </td>
                 <td class="border-r-2 border-(--nb-border) px-4 py-3 font-mono text-sm">
                   'none' | 'top' | 'right' | 'bottom' | 'left' | 'block' |
@@ -416,14 +416,14 @@ interface SectionLayoutDemo {
                   'none'
                 </td>
                 <td class="px-4 py-3">
-                  Which side(s) render a border. Uses
+                  Which side(s) render a divider line. Uses
                   <code class="font-mono">--nb-border</code> and
                   <code class="font-mono">--nb-border-width</code>.
                 </td>
               </tr>
               <tr class="border-b-2 border-(--nb-border)">
                 <td class="border-r-2 border-(--nb-border) px-4 py-3 font-mono text-sm">
-                  borderStyle
+                  dividerStyle
                 </td>
                 <td class="border-r-2 border-(--nb-border) px-4 py-3 font-mono text-sm">
                   'solid' | 'dashed' | 'dotted'
@@ -496,7 +496,7 @@ export default class SectionPage {
   protected readonly importCode = `import { NbSection } from '@ng-brutalism/ui';`;
 
   protected readonly defaultExampleCode = `<div nbSurface tone="cream" shadow="hard" radius="lg" clip>
-  <div nbSection border="bottom" padding="lg" layout="between" align="center">
+  <div nbSection divider="bottom" padding="lg" layout="between" align="center">
     <h2 nbDisplay>Alpha Launch</h2>
     <span nbChip tone="mint">Active</span>
   </div>
@@ -505,7 +505,7 @@ export default class SectionPage {
     <p>Section owns the inner regions of a card.</p>
   </div>
 
-  <div nbSection border="top" padding="lg" layout="between" align="center">
+  <div nbSection divider="top" padding="lg" layout="between" align="center">
     <span>12 collaborators</span>
     <button nbButton>Open project</button>
   </div>
@@ -518,24 +518,24 @@ export default class SectionPage {
 <div nbSection padding="lg">...</div>
 <div nbSection padding="xl">...</div>`;
 
-  protected readonly bordersExampleCode = `<div nbSection border="top">...</div>
-<div nbSection border="right">...</div>
-<div nbSection border="bottom">...</div>
-<div nbSection border="left">...</div>
-<div nbSection border="block">...</div>
-<div nbSection border="inline">...</div>
-<div nbSection border="all">...</div>`;
+  protected readonly bordersExampleCode = `<div nbSection divider="top">...</div>
+<div nbSection divider="right">...</div>
+<div nbSection divider="bottom">...</div>
+<div nbSection divider="left">...</div>
+<div nbSection divider="block">...</div>
+<div nbSection divider="inline">...</div>
+<div nbSection divider="all">...</div>`;
 
-  protected readonly borderStylesExampleCode = `<div nbSection border="all" borderStyle="solid">...</div>
-<div nbSection border="all" borderStyle="dashed">...</div>
-<div nbSection border="all" borderStyle="dotted">...</div>`;
+  protected readonly borderStylesExampleCode = `<div nbSection divider="all" dividerStyle="solid">...</div>
+<div nbSection divider="all" dividerStyle="dashed">...</div>
+<div nbSection divider="all" dividerStyle="dotted">...</div>`;
 
   protected readonly layoutsExampleCode = `<div nbSection layout="default">...</div>
 <div nbSection layout="center" align="center">...</div>
 <div nbSection layout="between" align="center">...</div>`;
 
   protected readonly compositionExampleCode = `<div nbSurface tone="white" shadow="hard" radius="lg" clip>
-  <div nbSection padding="lg" border="bottom" layout="between" align="center">
+  <div nbSection padding="lg" divider="bottom" layout="between" align="center">
     <h2 nbDisplay>Design Sprint</h2>
     <span nbChip tone="lavender">Annual</span>
   </div>
@@ -544,7 +544,7 @@ export default class SectionPage {
     <p>Three weeks of guided sessions and a final brutalist showcase.</p>
   </div>
 
-  <div nbSection border="top" padding="lg" layout="between" align="center">
+  <div nbSection divider="top" padding="lg" layout="between" align="center">
     <div nbCallout tone="yellow" shadow="hard">$799</div>
     <button nbButton>Enroll</button>
   </div>
@@ -567,13 +567,13 @@ export default class SectionPage {
     { value: 'block', label: 'block', hint: 'top + bottom' },
     { value: 'inline', label: 'inline', hint: 'left + right' },
     { value: 'all', label: 'all', hint: 'fully outlined' },
-  ] satisfies readonly SectionBorderDemo[];
+  ] satisfies readonly SectionDividerDemo[];
 
   protected readonly borderStyles = [
     { value: 'solid', label: 'solid' },
     { value: 'dashed', label: 'dashed' },
     { value: 'dotted', label: 'dotted' },
-  ] satisfies readonly SectionBorderStyleDemo[];
+  ] satisfies readonly SectionDividerStyleDemo[];
 
   protected readonly layouts = [
     {

--- a/apps/docs/src/app/pages/recipes/job-card/index.page.ts
+++ b/apps/docs/src/app/pages/recipes/job-card/index.page.ts
@@ -209,7 +209,7 @@ export default class JobCardRecipePage {
   </div>
 
   <!-- Footer: requirements + CTA -->
-  <div nbSection border="top" padding="lg">
+  <div nbSection divider="top" padding="lg">
     <div nbSplit ratio="2:1" gap="lg" collapse="md">
       <div nbCluster gap="lg" align="center" divider="dashed"
            class="[--nb-media-item-title-size:12px]">

--- a/apps/docs/src/app/pages/recipes/job-card/job-card.ts
+++ b/apps/docs/src/app/pages/recipes/job-card/job-card.ts
@@ -126,7 +126,7 @@ import {
           </div>
         </div>
 
-        <div nbSection border="top" padding="lg">
+        <div nbSection divider="top" padding="lg">
           <div nbSplit ratio="2:1" gap="lg" collapse="md">
             <div
               nbCluster

--- a/apps/docs/src/app/pages/recipes/podcast-card/index.page.ts
+++ b/apps/docs/src/app/pages/recipes/podcast-card/index.page.ts
@@ -246,7 +246,7 @@ export default class PodcastCardRecipePage {
   </div>
 
   <!-- Host section -->
-  <div nbSection border="top" padding="lg">
+  <div nbSection divider="top" padding="lg">
     <div nbCluster gap="lg" align="center">
       <img src="/podcast-card/avatar.png" alt="Kai Nguyen"
            class="w-16 h-16 rounded-full" />

--- a/apps/docs/src/app/pages/recipes/podcast-card/podcast-card.ts
+++ b/apps/docs/src/app/pages/recipes/podcast-card/podcast-card.ts
@@ -139,7 +139,7 @@ import {
             </div>
           </div>
 
-          <div nbSection border="top" padding="lg" class="z-10">
+          <div nbSection divider="top" padding="lg" class="z-10">
             <div nbStack gap="md" class="relative z-10">
               <div nbCluster gap="lg" align="start">
                 <img

--- a/apps/docs/src/app/pages/recipes/travel-card/index.page.ts
+++ b/apps/docs/src/app/pages/recipes/travel-card/index.page.ts
@@ -228,7 +228,7 @@ export default class TravelCardRecipePage {
   </div>
 
   <!-- Features + CTA -->
-  <div nbSection border="top" padding="lg">
+  <div nbSection divider="top" padding="lg">
     <div nbSplit ratio="2:1" gap="lg" collapse="md">
       <div nbCluster gap="lg" align="center" divider="dashed"
            class="[--nb-media-item-title-size:12px]">

--- a/apps/docs/src/app/pages/recipes/travel-card/travel-card.ts
+++ b/apps/docs/src/app/pages/recipes/travel-card/travel-card.ts
@@ -128,7 +128,7 @@ import {
           </div>
         </div>
 
-        <div nbSection border="top" padding="lg">
+        <div nbSection divider="top" padding="lg">
           <div nbSplit ratio="2:1" gap="lg" collapse="md">
             <div
               nbCluster

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -60,6 +60,7 @@ Agent session protocol:
 | `docs/components/primitives-roadmap.md` | Brutalist primitives roadmap — failure modes, decisions, candidate primitives, next steps | Yes |
 | `docs/components/composition-philosophy.md` | ng-brutalism + `nbText` + Tailwind boundary — when to add an input vs. reach for Tailwind | Yes |
 | `docs/components/style-capabilities.md` | Internal style-capability architecture (tokens → capabilities → hostDirectives → component CSS vars) + migration summary | Yes |
+| `docs/architecture/api-consistency-audit.md` | API consistency audit — shared token rules, primitive responsibility matrix, naming/default/CSS-var decisions, capability candidates, breaking changes + migration order | Yes |
 | `docs/components/contact-dialog/PLAN.md` | Contact dialog redesign — status + design decisions | Yes |
 | `docs/adr/0001-dialog-native-element.md` | ADR: why native `<dialog>` over overlay approach | No |
 | `CONTEXT.md` (root) | Project glossary — `Nb` prefix, v0.x contract, CSS transform patterns | Yes |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -59,6 +59,7 @@ Agent session protocol:
 |---|---|---|
 | `docs/components/primitives-roadmap.md` | Brutalist primitives roadmap — failure modes, decisions, candidate primitives, next steps | Yes |
 | `docs/components/composition-philosophy.md` | ng-brutalism + `nbText` + Tailwind boundary — when to add an input vs. reach for Tailwind | Yes |
+| `docs/components/style-capabilities.md` | Internal style-capability architecture (tokens → capabilities → hostDirectives → component CSS vars) + migration summary | Yes |
 | `docs/components/contact-dialog/PLAN.md` | Contact dialog redesign — status + design decisions | Yes |
 | `docs/adr/0001-dialog-native-element.md` | ADR: why native `<dialog>` over overlay approach | No |
 | `CONTEXT.md` (root) | Project glossary — `Nb` prefix, v0.x contract, CSS transform patterns | Yes |

--- a/docs/architecture/api-consistency-audit.md
+++ b/docs/architecture/api-consistency-audit.md
@@ -1,0 +1,722 @@
+# API Consistency Audit
+
+> **Status:** Decision document. Audited 2026-06-01 against the actual code on
+> `refactor/api-consistency-audit`. The internal style-capability layer
+> (`tokens → capabilities → hostDirectives → component CSS vars`) has already
+> landed for the visual-grammar primitives; this audit closes the remaining
+> drift **before** the next wave of the refactor (folding Button/IconButton tone
+> into the tone capability, removing local token maps).
+>
+> Companion docs: [`style-capabilities.md`](../components/style-capabilities.md)
+> (how the capability layer works) and
+> [`composition-philosophy.md`](../components/composition-philosophy.md)
+> (ng-brutalism vs `nbText` vs Tailwind boundaries).
+
+Guiding rule for every decision below:
+
+```txt
+Same concept = same name, same type, same meaning.
+Different concept = different name.
+Repeated implementation = shared token/capability candidate.
+Primitive-specific behavior = stays in the primitive.
+Recipe-specific layout = stays as Tailwind.
+```
+
+---
+
+## 1. Executive summary
+
+The shared token vocabulary (`NbRadius`, `NbShadow`, `NbBorderStrength`,
+`NbSpacing`, `NbPadding`, `NbDivider`, `nbToneVars`) and six internal
+capabilities (`tone`, `radius`, `shadow`, `border`, `padding`, `gap`) are in
+place and adopted by the **container/layout** primitives (Surface, MediaFrame,
+Chip, Callout, Section, Stack, Cluster, Split). For those primitives a token now
+means the same thing everywhere and writes a predictable `--nb-<ns>-<prop>`
+variable. That part of the language is healthy.
+
+The remaining drift is concentrated in five places:
+
+1. **`size` scale split** — `sm | md | lg | xl` (Button, Callout) vs
+   `sm | default | lg | xl` (IconButton, Display). `md` and `default` are the
+   same rung under two names. **High priority.**
+2. **Three color systems for one concept** — the shared `tone` capability;
+   Button's `variant` (preset) + `tone` (override) hybrid; and hardcoded color
+   maps in IconButton, MediaItem, and StatusDot. MediaItem even hardcodes hex
+   literals (`#ffd84d`) that duplicate the `--nb-yellow` theme token and *will*
+   drift. **High priority.**
+3. **`divider` means two different things** — placement (`top/bottom/…`) on
+   Section, but line *style* (`solid/dashed/thick`) on Stack/Cluster/Split.
+   **High priority (naming collision).**
+4. **Duplicated token type definitions** — `NbMediaItemTone` and
+   `NbIconButtonRadius` re-declare unions that already exist as `NbTone` /
+   `NbRadius`, and IconButton's radius *values* don't even match the shared
+   scale. **Medium.**
+5. **Typography leaking onto non-text primitives** — Button exposes
+   `fontSize`, `weight`, `transform`, `tracking`; these belong to `nbText`.
+   **High (recipe-facing).**
+
+None of these require breaking the capability architecture — they are
+follow-through. This document fixes the *language*; the next refactor PR
+implements it.
+
+---
+
+## 2. Current API inventory
+
+Captured from code. "CSS vars written" = variables the primitive (or its
+composed capabilities) emits; "Class-based only" = no custom-property contract.
+
+| Primitive | Selector | Current inputs | Current defaults | CSS vars written | Capability adoption | Notes |
+|---|---|---|---|---|---|---|
+| Surface | `[nbSurface]` | tone, radius, shadow, border, size, layout, padding, edge, clip | tone `default`, radius `md`, shadow `default`, border `default`, size `auto`, layout `block`, padding `none`, edge `none`, clip `false` | `--nb-surface-{bg,fg,border-color,radius,border-width,shadow}` | tone+radius+shadow+border | `padding` is a **local** 4-step Tailwind map, not the shared scale; `size` = square dimensions; `edge` = top/bottom hairline |
+| MediaFrame | `[nbMediaFrame]` | tone, radius, shadow, border, ratio, fit | tone `default`, radius `lg`, shadow `none`, border `default`, ratio `auto`, fit `cover` | `--nb-media-frame-{bg,fg,border-color,radius,border-width,shadow}` | tone+radius+shadow+border | Clean. `ratio`/`fit` are correct anatomy |
+| Button | `button[nbButton], a[nbButton]` | variant, tone, shadow, size, fontSize, weight, transform, tracking, radius, fullWidth | variant `default`, tone `undefined`, shadow `default`, size `md`, weight `bold`, transform `none`, tracking `normal`, radius `md`, fullWidth `false` | `--nb-button-{bg,fg,radius}` (+ local `-border,-border-width,-shadow`) | **radius only** | `variant`+`tone` dual color system; `shadow` encodes hover-translate; typography inputs leak |
+| IconButton | `button[nbIconButton]` | shape, size, radius, variant, icon | shape `square`, size `default`, radius `none`, variant `default` | `--nb-icon-button-{bg,fg,border,radius}` (all local) | **none** | Local radius map (`md`=`0.5rem` ≠ shared `var(--nb-radius)`); local variant map; hardcoded `border-2` + hover-translate |
+| Chip | `span[nbChip]` | tone, radius, shadow, padding, icon, iconSize | tone `default`, radius `none`, shadow `sm`, padding `md`, iconSize `sm` | `--nb-chip-{bg,fg,border-color,radius,shadow}` | tone+radius+shadow | `padding` is **local** asymmetric pill anatomy (intentional); hardcodes `border-2` (no border capability) |
+| Callout | `[nbCallout]` | tone, shadow, size, layout, radius | tone `yellow`, shadow `hard`, size `lg`, layout `inline`, radius `undefined` | `--nb-callout-{bg,fg,border-color,shadow}` (+ size-derived `-radius,-border-width`) | tone+shadow | radius/border-width are size-derived anatomy; optional `radius` override uses shared `nbRadiusValue` |
+| Section | `[nbSection]` | padding, divider, dividerStyle, layout, align, flush | padding `md`, divider `none`, dividerStyle `solid`, layout `default`, align `stretch`, flush `false` | `--nb-section-padding` | padding | `divider` = **placement** (`NbDivider`). Already renamed from `border` ✓ |
+| Stack | `[nbStack]` | gap, align, justify, divider | gap `md`, align `stretch`, justify `start`, divider `none` | `--nb-stack-gap` | gap | `divider` = **line style** (`solid/dashed/thick`) — collides with Section's meaning |
+| Cluster | `[nbCluster]` | gap, padding, align, justify, wrap, divider | gap `md`, padding `none`, align `center`, justify `start`, wrap `wrap`, divider `none` | `--nb-cluster-{gap,padding}` | gap+padding | same `divider`=style collision |
+| Split | `[nbSplit]` | ratio, gap, padding, collapse, align, divider | ratio `1:1`, gap `lg`, padding `none`, collapse `md`, align `stretch`, divider `none` | `--nb-split-{gap,padding}` | gap+padding | same `divider`=style collision; `ratio`/`collapse` correct anatomy |
+| Text | `[nbText]` | size, weight, tone, transform, tracking, measure, leading, underline, reset | size `md`, weight `normal`, tone `default`, transform `none`, tracking `normal`, measure `none`, leading `normal`, underline `none`, reset `true` | inline `[style.*]` (color, font-size, …) | none (typography owner) | Typography authority. `tone` is a text-specific palette (muted/subtle/inverse) |
+| Display | `[nbDisplay]` | size, tracking, leading, underline, reset | size `default`, tracking `tight`, leading `none`, underline `none`, reset `true` | `--nb-display-{size,color}` consumed | none | `size` uses `default` (not `md`); headline typography |
+| MediaItem | `nb-media-item, [nbMediaItem]` | variant, orientation, align, size, tone, icon, iconAlt, iconBackground, title, description | variant `plain`, orientation `horizontal`, align `start`, size `md`, tone `default` | `--nb-media-item-*` (all local) | none | **Hardcoded hex tone map** duplicates theme tokens; `NbMediaItemTone` re-declares `NbTone` |
+| Stat | `nb-stat` | value, label, direction | direction `column` | `--nb-stat-{value-size,label-size,label-fg}` (local) | none | Composition block; no shared tokens |
+| StatusDot | `span[nbStatusDot]` | state | state `online` | `--nb-status-dot-size` consumed | none | Uses semantic theme colors directly, not `tone` |
+| Sticker / StickerFace | `nb-sticker*` | (decorative) | — | `--nb-sticker-*` (local) | none | Decorative art; out of token scope |
+| Halftone | `nb-halftone` | position, color, size, gap, rows, cols | position `bottom-right`, color `var(--nb-border)`, size `6`, gap `5`, rows `7`, cols `7` | None (SVG attrs) | none | Decorative art; `gap`/`size` here are **numeric SVG geometry**, not tokens |
+
+**Interactive/form components (high-level only):** `nbInput`, `nbTextarea`,
+`nbCheckbox` expose `size` (`default`-based scale); `nbSelect`, `nbInputGroup`
+(`nbInputPrefix` `align`), `nbDialog`, `nbAccordion` are composition components
+with no shared visual-grammar tokens yet. They are out of scope for the
+visual-grammar capability refactor but **must** adopt the canonical `size` scale
+(§4.7) and any future control-tone capability.
+
+---
+
+## 3. Primitive responsibility matrix
+
+Meanings: **Yes** = should own · **Maybe** = own only if repeated real use ·
+**No** = should not own · **Default only** = may set default text appearance,
+custom typography belongs to `nbText`.
+
+| Primitive | Tone | Radius | Shadow | Border | Divider | Padding | Gap | Size | Typography | Notes |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| nbSurface | Yes | Yes | Yes | Yes | No | Maybe | No | Questionable | No | Visual shell |
+| nbSection | No | No | No | No | **Yes** | Yes | No | No | No | Layout region + divider placement |
+| nbStack | No | No | No | No | Maybe* | No | Yes | No | No | Vertical layout (*separator = style, rename) |
+| nbCluster | No | No | No | No | Maybe* | Maybe | Yes | No | No | Inline/wrap layout |
+| nbSplit | No | No | No | No | Maybe* | Maybe | Yes | No | No | Two-column responsive split |
+| nbMediaFrame | Yes | Yes | Yes | Yes | No | No | No | No | No | Media wrapper |
+| nbButton | Yes | Yes | Yes | Yes | No | No | No | Yes | Default only | Interaction surface |
+| nbIconButton | Yes | Yes | Yes | Yes | No | No | No | Yes | No | Square action |
+| nbChip | Yes | Yes | Maybe | Yes | No | Yes† | No | Yes | Default only | Compact label (†pill anatomy padding) |
+| nbCallout | Yes | Yes | Yes | Yes | No | Yes† | Maybe | Yes | Default only | Announcement (†size-derived anatomy) |
+| nbText | Tone only | No | No | No | No | No | No | Yes | Yes | Typography owner |
+| nbDisplay | Tone only | No | No | No | No | No | No | Yes | Yes | Display typography |
+| nbMediaItem | Yes‡ | No | No | No | No | No | No | Yes | Default only | Composition block (‡via tone capability, not hex) |
+| nbStat | No | No | No | No | No | No | No | No | Default only | Composition block |
+| nbStatusDot | Maybe | No | No | No | No | No | No | Maybe | No | Status indicator (semantic color) |
+| nbSticker | No | No | No | No | No | No | No | No | No | Decorative |
+| nbHalftone | No | No | No | No | No | No | No | No | No | Decorative |
+
+`* divider` on layout primitives is a **child-separator line style**, a
+different concept from Section's placement `divider` — see §4.4 / §5.
+
+### Per-primitive responsibility statements
+
+**nbSurface** — brutalist visual shell for grouping content.
+Owns: tone, border strength, radius, shadow, optional convenience padding,
+clipping. Does not own: page layout, responsive visibility, arbitrary
+width/height as a primary job, custom typography, decorative positioning.
+*Open question:* `size` (square dimensions) is the only "Questionable" cell —
+see §4.7 / §10.
+
+**nbSection** — layout region: internal container padding + optional divider
+placement. Owns: padding, divider placement + style, internal layout
+(default/center/between), align. Does not own: tone, radius, shadow, border
+strength.
+
+**nbStack** — vertical flex layout. Owns: gap, align, justify, optional
+between-child separator. Does not own: visual-shell tokens.
+
+**nbCluster** — inline/wrapping flex layout. Owns: gap, optional padding, align,
+justify, wrap, optional separator. Does not own: visual-shell tokens.
+
+**nbSplit** — two-column responsive split. Owns: ratio, collapse breakpoint,
+gap, optional padding, align, optional column divider. Does not own:
+visual-shell tokens.
+
+**nbMediaFrame** — image/video/object frame. Owns: tone, radius, shadow, border,
+aspect ratio, object fit. Does not own: layout, typography.
+
+**nbButton** — interactive action surface. Owns: tone, radius, shadow, border,
+size (interactive density), interaction/focus/disabled state, **default**
+typography. Does not own: custom expressive typography (→ `nbText`).
+
+**nbIconButton** — square interactive action. Owns: tone, radius, shadow,
+border, size (square dimensions), shape (square/circle). Does not own:
+typography.
+
+**nbChip** — compact label/status/action token. Owns: tone, radius, shadow,
+border, pill padding (anatomy), size (density), **default** typography. Does not
+own: custom typography, layout.
+
+**nbCallout** — attention/announcement block. Owns: tone, radius, shadow,
+border, size (block scale → anatomy), layout (inline/between/center), **default**
+typography. Does not own: custom typography.
+
+**nbText / nbDisplay** — typography owners. Own: size, weight, tracking,
+transform, leading, measure, underline treatment, text tone. Do not own: shells,
+shadows, borders, layout.
+
+**nbMediaItem / nbStat** — composition blocks built *from* primitives. Own their
+anatomy + default typography; should consume the **tone capability** rather than
+re-declaring color maps.
+
+**nbStatusDot / nbSticker / nbHalftone** — indicators and decorative art. Out of
+the shared-token scope (StatusDot may optionally narrow `tone` later).
+
+---
+
+## 4. Input family audit
+
+For each family: current usage · inconsistencies · recommended shared type ·
+ownership · capability status · public API decision.
+
+### 4.1 `tone`
+
+**Current usage.** Shared `NbToneToken` (15-value `NbTone` palette + `surface`/
+`background`/`ink` aliases) flows through `NbToneCapability` into Surface,
+MediaFrame, Chip, Callout — these resolve `bg`/`fg`/`border-color` from the
+single `nbToneVars()` resolver. **Three other systems exist in parallel:**
+
+- **Button**: `variant` (preset enum: default/neutral/primary/…/warning) **plus**
+  `tone` (full `NbTone` override). Writes `--nb-button-bg/-fg` directly via
+  `nbToneTokens()` — bypasses the capability.
+- **IconButton**: `variant` only, hardcoded class map; no `tone`, no capability.
+- **MediaItem**: `tone` with a **hardcoded hex map** (`#ffd84d`, `#ff7eb6`, …)
+  that duplicates the `--nb-yellow`/`--nb-pink`/… theme tokens. `NbMediaItemTone`
+  re-declares the `NbTone` union literally.
+- **StatusDot**: semantic theme colors keyed off `state`, not `tone`.
+
+**Inconsistencies.** Same concept ("what color is this") under four
+implementations; one (MediaItem) holds literal hexes that *will* drift from the
+themeable palette; one type union is duplicated; Button carries two color axes.
+
+**Recommended shared type** (rationalize the existing 15-value `NbTone` into
+documented sub-families; values stay backward compatible):
+
+```ts
+export type NbSemanticTone = 'default' | 'primary' | 'secondary' | 'accent'
+  | 'success' | 'warning' | 'danger';
+export type NbPlayfulTone  = 'yellow' | 'pink' | 'mint' | 'lavender' | 'blue';
+export type NbNeutralTone  = 'cream' | 'white' | 'black' | 'surface' | 'background' | 'ink';
+export type NbTone = NbSemanticTone | NbPlayfulTone | NbNeutralTone;
+```
+
+**Ownership.** Every primitive that paints a bg/fg/border. **Capability:**
+already `NbToneCapability` — extend adoption.
+
+**Public API decision.**
+- Use shared `NbTone`/`NbToneToken` globally; primitives may *narrow* (Callout,
+  Chip) but never re-declare the full union (kill `NbMediaItemTone`).
+- MediaItem and IconButton adopt `NbToneCapability`; delete their hardcoded maps.
+- **Button:** fold `variant` semantic presets into `tone` post-1.0 (the
+  `variant`↔`tone` overlap is the single largest API smell). Until then, document
+  that `tone` overrides `variant`. Tracked in §10 as Medium (post-1.0).
+
+### 4.2 `radius`
+
+**Current usage.** Shared `NbRadius` (`none|sm|md|lg|xl|full`, `md` =
+`var(--nb-radius)`) via `NbRadiusCapability` on Surface, MediaFrame, Button,
+Chip. Callout derives radius from `size` with an optional shared override.
+
+**Inconsistencies.**
+- **IconButton** re-declares `NbIconButtonRadius` with the *same names* but
+  **different values** — `md` = `0.5rem` literal, vs the shared `md` =
+  `var(--nb-radius)`. Two `md`s that don't match: the exact drift this audit
+  exists to prevent.
+- No primitive uses `base` (good — that earlier inconsistency is already gone).
+
+**Recommended shared type.** Keep `NbRadius = none|sm|md|lg|xl|full`. Do not
+introduce `base`.
+
+**Ownership.** Shell + control primitives. **Capability:** `NbRadiusCapability`.
+
+**Public API decision.** IconButton adopts `NbRadiusCapability`; delete
+`NbIconButtonRadius` and its local value map. `md` resolves to `var(--nb-radius)`
+everywhere.
+
+### 4.3 `shadow`
+
+**Current usage.** Shared `NbShadow` (`none|sm|default|hard|heavy`) via
+`NbShadowCapability` on Surface, MediaFrame, Chip, Callout (Callout narrows to
+`none|default|hard`).
+
+**Inconsistencies.**
+- **Button** `shadow` = `default|none|reverse`. `default` *and* `reverse` encode
+  **hover-translate interaction**, not a static box-shadow. This conflates two
+  concepts: static `shadow` and interactive `press`.
+- **IconButton** has no `shadow` input; hover-translate is hardcoded.
+
+**Recommended split.**
+
+```txt
+shadow = static box-shadow (the NbShadow scale).
+press  = interactive offset/translate behavior (FUTURE — do not build yet).
+```
+
+**Ownership.** All shell/control primitives. **Capability:**
+`NbShadowCapability` for static shadow.
+
+**Public API decision.** Mark Button's `reverse` and the hover-translate baked
+into `default` as **questionable / press-behavior** (§9, §10). Do **not** design
+`press` in this pass. Keep Button/IconButton interaction as-is for now; record
+`press` as a future capability candidate so the next refactor can extract it.
+
+### 4.4 `border`
+
+**Current usage.** Shared `NbBorderStrength` (`none|thin|default|strong|thick`,
+width only — color comes from tone) via `NbBorderCapability` on Surface,
+MediaFrame. Callout derives border-width from `size`.
+
+**Inconsistencies.**
+- **Chip, Button, IconButton** hardcode `border-2` and do **not** compose the
+  border capability — so border strength is not adjustable and not consistent
+  with Surface/MediaFrame.
+- **The `border` vs `divider` conflict is already resolved** in code: Section's
+  former `border="bottom"` is now `divider="bottom"` (placement), and `border`
+  means strength library-wide. ✓
+
+**Recommended types.**
+
+```txt
+border      = NbBorderStrength (outline width).
+divider     = NbDivider (separator placement) — Section.
+borderStyle = solid|dashed|dotted line style, only where a divider exists.
+```
+
+**Ownership.** Shell + control primitives (strength); Section (divider
+placement). **Capability:** `NbBorderCapability`.
+
+**Public API decision.** Chip/Button/IconButton adopt `NbBorderCapability` so
+`border` strength is uniform and overridable. Border *color* stays owned by the
+tone capability (never duplicated).
+
+### 4.5 `padding`
+
+**Current usage.** Shared `NbPadding` (`none|xs|sm|md|lg|xl`, uniform) via
+`NbPaddingCapability` on Section, Cluster, Split.
+
+**Inconsistencies.**
+- **Surface** has its own `NbSurfacePadding` (`none|sm|md|lg`) implemented as
+  Tailwind `px/py` classes — a different (narrower, asymmetric) scale.
+- **Chip** has `NbChipPadding` (`none|sm|md|lg|xl`) asymmetric pill padding —
+  intentionally primitive-local (documented in code).
+- **Callout** padding is size-derived anatomy.
+
+**Recommended shared type.** `NbPadding = none|xs|sm|md|lg|xl`.
+
+**Ownership.** Only primitives that own a **uniform container region**: Section
+(strong owner), Cluster, Split. **Capability:** `NbPaddingCapability`.
+
+**Public API decision.**
+- Section keeps strong ownership.
+- **Surface:** either adopt the shared `NbPadding` scale (preferred — fixes the
+  `none|sm|md|lg` vs `none|xs|sm|md|lg|xl` mismatch) or document that Surface
+  padding is convenience-only and asymmetric. Decision: **align to `NbPadding`**,
+  default `none`.
+- Chip & Callout padding stays **primitive-local anatomy** (asymmetric pill /
+  size-derived) — correct, do not force the capability.
+- Button/IconButton/Chip never expose raw container padding; **`size` owns
+  density**.
+
+### 4.6 `gap`
+
+**Current usage.** Shared `NbSpacing` (`none|xs|sm|md|lg|xl|2xl`) via
+`NbGapCapability` on Stack, Cluster, Split — fully consistent, single scale,
+no duplicated maps. ✓
+
+**Inconsistencies.** None among layout primitives. (MediaItem's
+`--nb-media-item-gap` is size-derived anatomy, not the layout gap; Halftone's
+`gap` is numeric SVG geometry, **not** this token — see naming note §5.)
+
+**Recommended shared type.** `NbGap = NbSpacing = none|xs|sm|md|lg|xl|2xl`.
+
+**Ownership.** Layout primitives only. **Capability:** `NbGapCapability`.
+
+**Public API decision.** Keep as-is. Good owners: nbStack, nbCluster, nbSplit,
+future nbGrid, future nbActions. Do **not** rename Halftone's numeric `gap`
+input — but document that it is geometry, not the spacing token (an acceptable
+contextual exception, like Split's `ratio`).
+
+### 4.7 `size`
+
+**Current usage / meanings.**
+
+| Primitive | `size` values | Meaning |
+|---|---|---|
+| nbButton | `sm \| md \| lg \| xl` | interactive density |
+| nbCallout | `sm \| md \| lg \| xl` | announcement block scale |
+| nbChip | (`padding` is the density knob) | — |
+| nbIconButton | `sm \| default \| lg \| xl` | square dimensions |
+| nbMediaItem | `sm \| md \| lg` | block scale |
+| nbSurface | `auto \| sm \| md \| lg \| xl` | **square dimensions** |
+| nbText | `xs \| sm \| md \| lg \| xl \| 2xl \| 3xl` | typography scale |
+| nbDisplay | `sm \| default \| lg \| xl` | headline scale |
+| nbInput/Textarea/Checkbox | `default`-based | control density |
+
+**Inconsistencies.**
+1. **`md` vs `default`** for the same middle rung — IconButton, Display, and the
+   form controls use `default`; Button, Callout, MediaItem use `md`. Pick one.
+2. **Surface `size`** means literal square dimensions (`size-10` etc.), which is
+   shell-as-avatar behavior — questionable for a "visual shell."
+
+**Recommended direction.** `size` is **not** a single shared token — it is
+component anatomy with a documented meaning per primitive. But the **rung names
+must be consistent**: standardize the middle rung as **`md`** (matches the radius
+/ shadow / spacing scales). Treat `default` as the deprecated alias.
+
+**Public API decision.**
+- Rename IconButton/Display/form-control middle rung `default` → `md`. **High**
+  for IconButton/Display (visual-grammar), **Medium** for form controls.
+- Keep `size` where it controls anatomy (Button, IconButton, Chip-density,
+  Callout, Text, Display).
+- **Surface `size`:** reconsider — a shell that needs fixed square dimensions is
+  usually better expressed with Tailwind `size-*`. Decision: keep for now,
+  document as "avatar/icon-shell convenience," flag for removal review (§10).
+  Do not expand it.
+
+### 4.8 Typography inputs
+
+**Current usage.**
+- **nbText** owns `size, weight, tone, transform, tracking, measure, leading,
+  underline` — the correct authority.
+- **nbDisplay** owns `size, tracking, leading, underline`.
+- **Button** *also* exposes `fontSize, weight, transform, tracking` — custom
+  typography on an action surface.
+- **Chip** bakes `text-xs font-bold` (default only — OK). **Callout** bakes
+  `font-black uppercase` (default only — OK). **Stat/MediaItem** set default
+  type sizes via local vars (default only — OK).
+
+**Inconsistencies.** Button is the leak: it duplicates four `nbText` concepts
+with a narrower, divergent vocabulary (`weight` = bold/extrabold/black vs
+nbText's normal…black; `tracking` = normal/wide/wider vs nbText's
+tight/normal/wide/wider).
+
+**Recommended direction.** `nbText` / `nbDisplay` own custom typography.
+Components provide **default** typography only.
+
+**Public API decision.** Deprecate Button's `fontSize`, `weight`, `transform`,
+`tracking`; steer recipes to a nested `nbText` (matches the documented pattern in
+`composition-philosophy.md`). Button keeps a sensible **default** weight per
+size. **High priority** because it directly shapes recipe authoring.
+
+```html
+<button nbButton tone="lavender" size="xl" radius="md">
+  <span nbText size="3xl" weight="black" transform="uppercase" tracking="wide">
+    Listen Now
+  </span>
+</button>
+```
+
+### 4.9 `align` / `justify` (layout sub-audit)
+
+**Current usage.** Stack/Cluster/Split/Section each expose alignment, with
+slightly divergent value sets:
+
+| Primitive | align | justify |
+|---|---|---|
+| nbStack | stretch\|start\|center\|end | start\|center\|end\|between |
+| nbCluster | start\|center\|end\|baseline\|stretch | start\|center\|end\|between |
+| nbSplit | start\|center\|end\|stretch | — (align only) |
+| nbSection | stretch\|start\|center\|end | folded into `layout` (default/center/between) |
+
+**Decision.** Define shared `NbAlign` and `NbJustify` types so the **shared**
+values mean the same thing; allow primitives to **add** axis-specific values
+(`baseline` for Cluster only). Section should expose `justify` rather than
+folding it into `layout` — **Low priority** (cosmetic, defer).
+
+---
+
+## 5. Naming consistency decisions
+
+### Naming rules (baseline)
+
+- `tone` — visual color intent (bg + fg + border-color).
+- `radius` — corner shape.
+- `shadow` — static box-shadow.
+- `border` — outline strength (width).
+- `divider` — separator **placement** (which side(s) carry a line).
+- `dividerStyle` — separator line style (solid/dashed/dotted) where a divider exists.
+- `padding` — internal container spacing (uniform).
+- `gap` — spacing between children (layout primitives).
+- `size` — component anatomy scale; documented per primitive; middle rung is `md`.
+- `fit` — media object fitting only.
+- `ratio` — aspect ratio (MediaFrame) / column ratio (Split) — contextual, documented.
+- `align` / `justify` — layout primitives only.
+- `weight`, `tracking`, `transform`, `leading`, `measure` — text primitives only.
+
+### Violations
+
+| Current API | Issue | Recommendation | Breaking? |
+|---|---|---|---|
+| `nbStack/Cluster/Split divider="solid\|dashed\|thick"` | `divider` means **line style** here but **placement** on Section — collision | Rename to `separator` (between-children) **or** repurpose as `divider` placement + `dividerStyle`; pick one library-wide vocabulary | Yes |
+| `nbIconButton size="default"`, `nbDisplay size="default"` | Middle rung named `default`, but `md` elsewhere | Rename `default` → `md` | Yes |
+| `nbInput/Textarea/Checkbox size="default"` | Same `default` vs `md` split | Rename `default` → `md` | Yes (forms) |
+| `nbButton fontSize/weight/transform/tracking` | Custom typography on a non-text primitive | Deprecate; use nested `nbText` | Yes (deprecate→remove) |
+| `NbMediaItemTone` (re-declared union) | Duplicate of `NbTone` | Alias to `NbTone`; adopt tone capability | No (type identical) |
+| `NbIconButtonRadius` (re-declared, mismatched values) | Duplicate of `NbRadius` with different `md` value | Delete; adopt `NbRadiusCapability` | Yes (value change) |
+| `nbButton variant` + `tone` | Two color axes for one concept | Fold `variant` into `tone` (post-1.0) | Yes (post-1.0) |
+| MediaItem hardcoded hex tone map | Duplicates `--nb-*` theme tokens; will drift | Replace with `nbToneVars()` | No (visual parity) |
+| `nbHalftone gap/size` (numeric) | Same names as spacing tokens but numeric geometry | Keep; document as geometry exception | No |
+
+---
+
+## 6. Default value audit
+
+### Current defaults (from code)
+
+| Primitive | tone | radius | shadow | border | padding | gap | size |
+|---|---|---|---|---|---|---|---|
+| nbSurface | default | md | default | default | none | – | auto |
+| nbMediaFrame | default | lg | none | default | – | – | – |
+| nbButton | (variant default) | md | default* | (local) | – | – | md |
+| nbIconButton | (variant default) | none | (hardcoded) | (border-2) | – | – | default |
+| nbChip | default | none | sm | (border-2) | md | – | – |
+| nbCallout | yellow | (size-derived) | hard | (size-derived) | (size) | – | lg |
+| nbSection | – | – | – | – | md | – | – |
+| nbStack | – | – | – | – | – | md | – |
+| nbCluster | – | – | – | – | none | md | – |
+| nbSplit | – | – | – | – | none | lg | – |
+| nbText | default | – | – | – | – | – | md |
+| nbDisplay | – | – | – | – | – | – | default |
+
+\* Button `shadow="default"` includes hover-translate (interaction), not just a
+static shadow.
+
+### Proposed default families
+
+These map into `NB_STYLE_DEFAULTS` per primitive.
+
+```txt
+Shell defaults (Surface, MediaFrame):
+  radius: xl        # see note
+  shadow: hard      # see note
+  border: strong    # see note
+
+Control defaults (Button, IconButton, Chip):
+  radius: md
+  shadow: default
+  border: default
+  size:   md
+
+Layout defaults (Stack, Cluster, Split, Section):
+  gap:     md   (Split lg)
+  padding: md (Section) / none (Cluster, Split)
+
+Typography defaults (Text, Display):
+  size:   md
+  weight: normal (Text) / black (Display anatomy)
+```
+
+> **Note — shell defaults are aspirational, not current.** Today Surface defaults
+> to `radius: md, shadow: default, border: default` and MediaFrame to
+> `radius: lg, shadow: none`. The brutalist house style ("chunky borders, offset
+> shadows") argues for the louder shell family (`radius: xl, shadow: hard,
+> border: strong`) as documented in `composition-philosophy.md`. **Decision:**
+> treat the shell family as the target, but changing live defaults is a
+> **breaking visual change** (§10, Medium) — confirm against the reference
+> designs before flipping. Do not change defaults in the audit.
+
+---
+
+## 7. CSS variable naming audit
+
+Pattern: `--nb-{namespace}-{property}`. Capability-driven primitives already
+follow it cleanly.
+
+| Primitive | Current variables | Missing / not-yet-capability | Naming issues | Recommendation |
+|---|---|---|---|---|
+| nbSurface | `--nb-surface-{bg,fg,border-color,border-width,radius,shadow}` + `--nb-surface-edge-{width,color}` | padding not a var (Tailwind classes) | none | Optionally emit `--nb-surface-padding` if Surface adopts `NbPadding` |
+| nbMediaFrame | `--nb-media-frame-{bg,fg,border-color,border-width,radius,shadow}` | — | none | ✓ reference-clean |
+| nbButton | `--nb-button-{bg,fg,radius}` + local `--nb-button-{border,border-width,shadow}` | tone/shadow/border via class, not capability | `--nb-button-border` is a *color* but reads like strength | When Button adopts tone/border/shadow capabilities, normalize to `--nb-button-border-color` + `--nb-button-border-width` |
+| nbIconButton | `--nb-icon-button-{bg,fg,border,radius}` (all local) | tone/radius/shadow/border capabilities | `--nb-icon-button-border` = color (same ambiguity) | Adopt capabilities; rename to `-border-color` / `-border-width` |
+| nbChip | `--nb-chip-{bg,fg,border-color,radius,shadow}` | border-width (hardcoded `border-2`) | none | Adopt border capability → `--nb-chip-border-width` |
+| nbCallout | `--nb-callout-{bg,fg,border-color,shadow,radius,border-width}` | radius/border-width size-derived (intentional) | none | OK; document size-derived anatomy |
+| nbSection | `--nb-section-padding` | — | none | ✓ |
+| nbStack | `--nb-stack-gap` | — | none | ✓ |
+| nbCluster | `--nb-cluster-{gap,padding}` + `--nb-cluster-divider-*` | — | none | ✓ |
+| nbSplit | `--nb-split-{gap,padding,columns}` | — | none | ✓ |
+| nbMediaItem | `--nb-media-item-*` (bg, fg, radius, gap, icon-size, …, **hex via tone class**) | tone via capability | tone values are literal hex, not theme vars | Adopt tone capability → `--nb-media-item-{bg,fg,border-color}` from `nbToneVars()` |
+| nbStat | `--nb-stat-{value-size,label-size,label-fg}` | — | none | OK (composition block) |
+| nbStatusDot | `--nb-status-dot-size` | — | none | OK |
+
+**Rules confirmed:** variables are component-specific (no generic
+`--nb-radius`-as-output), names match public inputs, and users can override them
+from CSS. The two real issues are (a) `--nb-*-border` used for *color* on
+Button/IconButton (should be `-border-color`), and (b) MediaItem's hex literals.
+
+---
+
+## 8. Shared token contracts
+
+Centralized in `libs/ui/src/lib/tokens/*` (already exist except where noted).
+
+### NbTone
+**Purpose:** shared visual color grammar (bg + fg + border-color).
+**Values:** semantic (default, primary, secondary, accent, success, warning,
+danger) · playful (yellow, pink, mint, lavender, blue) · neutral (cream, white,
+black, surface, background, ink). **Used by:** Surface, MediaFrame, Chip,
+Callout, (target) Button, IconButton, MediaItem. **Capability candidate:** Yes —
+`NbToneCapability` (exists; widen adoption).
+
+### NbRadius
+**Purpose:** shared corner scale. **Values:** none, sm, md, lg, xl, full
+(`md` = `var(--nb-radius)`). **Used by:** Surface, MediaFrame, Button, Chip,
+(target) IconButton, Callout-override. **Capability:** `NbRadiusCapability` (exists).
+
+### NbShadow
+**Purpose:** static offset box-shadow scale. **Values:** none, sm, default, hard,
+heavy. **Used by:** Surface, MediaFrame, Chip, Callout, (target) Button.
+**Capability:** `NbShadowCapability` (exists). *Companion future token: `press`.*
+
+### NbBorderStrength
+**Purpose:** outline width (color from tone). **Values:** none, thin, default,
+strong, thick. **Used by:** Surface, MediaFrame, (target) Chip, Button,
+IconButton. **Capability:** `NbBorderCapability` (exists).
+
+### NbPadding
+**Purpose:** uniform container padding. **Values:** none, xs, sm, md, lg, xl.
+**Used by:** Section, Cluster, Split, (target) Surface. **Capability:**
+`NbPaddingCapability` (exists).
+
+### NbSpacing (gap)
+**Purpose:** layout gap between children. **Values:** none, xs, sm, md, lg, xl,
+2xl. **Used by:** Stack, Cluster, Split. **Capability:** `NbGapCapability`
+(exists). *Recommend a `NbGap = NbSpacing` alias for input-facing clarity.*
+
+### NbDivider
+**Purpose:** separator placement between regions. **Values:** none, top, right,
+bottom, left, block, inline, all. **Used by:** Section. **Capability:** No —
+placement is layout-specific (not a uniform value write).
+
+### Typography contracts (text primitives only)
+- **NbTextSize:** xs, sm, md, lg, xl, 2xl, 3xl.
+- **NbTextWeight:** normal, medium, semibold, bold, extrabold, black.
+- **NbTextTracking:** tight, normal, wide, wider.
+- **NbTextTransform:** none, uppercase, lowercase, capitalize.
+Used by: nbText (and a narrowed subset by nbDisplay). **Capability candidate:**
+No — typography is the text primitives' job, not a cross-cutting capability.
+
+---
+
+## 9. Internal capability directive candidates
+
+Capabilities are **internal only** — never exported as public user-facing
+directives. Primitives expose the public inputs; capabilities remove internal
+duplication.
+
+| Capability | Status | Public input | Writes CSS vars | Used by | Notes |
+|---|---|---|---|---|---|
+| NbToneCapability | **Exists** | tone | `--nb-{ns}-{bg,fg,border-color}` | Surface, MediaFrame, Chip, Callout → +Button, IconButton, MediaItem | Widen adoption; kill hex map |
+| NbRadiusCapability | **Exists** | radius | `--nb-{ns}-radius` | Surface, MediaFrame, Button, Chip → +IconButton | Kill `NbIconButtonRadius` |
+| NbShadowCapability | **Exists** | shadow | `--nb-{ns}-shadow` | Surface, MediaFrame, Chip, Callout → +Button (static part) | Split static vs press |
+| NbBorderCapability | **Exists** | border | `--nb-{ns}-border-width` | Surface, MediaFrame → +Chip, Button, IconButton | Color stays with tone |
+| NbPaddingCapability | **Exists** | padding | `--nb-{ns}-padding` | Section, Cluster, Split → +Surface (opt) | Container-owners only |
+| NbGapCapability | **Exists** | gap | `--nb-{ns}-gap` | Stack, Cluster, Split | ✓ complete |
+| **NbPressCapability** | **Future** | press | `--nb-{ns}-press-*` / translate behavior | Button, IconButton | Extract Button/IconButton hover-translate; **do not build yet** |
+
+Rules: capabilities stay internal; primitives expose public inputs; resolution is
+`explicit input → NB_STYLE_DEFAULTS → capability fallback`.
+
+---
+
+## 10. Breaking changes to consider
+
+| Change | Reason | Impact | Priority |
+|---|---|---|---|
+| Resolve `divider` collision (Stack/Cluster/Split line-style vs Section placement) | One name, two meanings | Rename layout `divider`→`separator` (or unify vocab); update recipes/docs | **High** |
+| Rename `size="default"`→`"md"` (IconButton, Display) | Middle-rung name drift | Update usages + recipes | **High** |
+| Deprecate Button `fontSize/weight/transform/tracking` | Typography belongs to nbText | Migrate recipes to nested `nbText` | **High** |
+| MediaItem: replace hex tone map with `nbToneVars()` + adopt tone capability | Hardcoded hex drifts from theme tokens | Visual parity expected; verify | **High** |
+| Delete `NbIconButtonRadius`; adopt `NbRadiusCapability` | Duplicate type + mismatched `md` value | `md` value changes (`0.5rem`→`var(--nb-radius)`) | **High** |
+| Alias `NbMediaItemTone = NbTone` | Duplicate union | Type-only, no runtime change | Medium |
+| Chip/Button/IconButton adopt `NbBorderCapability` | `border` strength should be uniform/overridable | New input surface; default `default`/strength 2px parity | Medium |
+| `size="default"`→`"md"` (Input/Textarea/Checkbox) | Same drift, forms | Update form usages | Medium |
+| Fold Button `variant` into `tone` | Two color axes for one concept | Large; post-1.0 | Medium (post-1.0) |
+| Surface padding: adopt shared `NbPadding` scale | `none\|sm\|md\|lg` ≠ shared `none\|xs\|sm\|md\|lg\|xl` | Add `xs/xl`; values may shift | Medium |
+| Flip shell defaults to `radius xl / shadow hard / border strong` | House style; louder brutalism | Visual change across Surface/MediaFrame | Medium (verify vs reference designs) |
+| Extract `NbPressCapability` | Separate static shadow from interaction | Button/IconButton internals | Medium (after tone/border) |
+| Reconsider Surface `size` (square dims) | Shell vs Tailwind `size-*` | Maybe remove; document meanwhile | Low |
+| Section expose `justify` instead of folding into `layout` | align/justify consistency | Minor API addition | Low |
+
+Priority key: **High** = before the capability-adoption refactor · **Medium** =
+during it · **Low** = document and revisit.
+
+---
+
+## 11. Migration priorities
+
+1. **Settle naming decisions** — `divider` collision, `size` `default`→`md`,
+   Button typography ownership. *(Language must be final before code moves.)*
+2. **Centralize remaining token types** — alias `NbMediaItemTone`/
+   `NbIconButtonRadius` to shared contracts; add `NbGap`/`NbAlign`/`NbJustify`
+   aliases.
+3. **Widen capability adoption** — IconButton (tone+radius+shadow+border),
+   MediaItem (tone), Chip/Button (border).
+4. **Normalize CSS var names** — `--nb-*-border` color→`-border-color` on
+   Button/IconButton.
+5. **Refactor Surface / Button / MediaFrame first** — they validate the visual
+   grammar end to end.
+6. **Refactor Stack / Cluster / Split** — already gap-clean; finish the
+   separator/divider rename to validate layout grammar.
+7. **Refactor Chip / Callout** — validate compact/block anatomy.
+8. **Update recipes**, starting with `podcast-card.ts` — proves real composition.
+9. **Update docs** — `style-capabilities.md`, `composition-philosophy.md`,
+   `primitives-roadmap.md`, and this audit's "target → shipped" status.
+
+Why this order: Surface/Button/MediaFrame validate the visual grammar;
+Stack/Cluster/Split validate the layout grammar; Chip/Callout validate
+compact/block anatomy; the Podcast Card validates real recipe composition.
+
+---
+
+## 12. Final rules for future primitives
+
+1. Same concept must use the same input name and the shared token type.
+2. Different concepts must not share the same input name (see `divider`).
+3. `tone` controls visual color intent (bg + fg + border-color).
+4. `radius` controls corner shape.
+5. `shadow` controls static box-shadow; interaction movement is a separate
+   (future) `press` concern.
+6. `border` controls outline strength (width); color comes from tone.
+7. `divider` controls separator placement; `dividerStyle` controls its line style.
+8. `padding` controls uniform internal spacing, only on primitives that own a
+   container region.
+9. `gap` controls spacing between children and belongs to layout primitives.
+10. `size` controls component anatomy scale, is documented per primitive, and its
+    middle rung is named `md` (never `default`).
+11. Custom typography belongs to `nbText` / `nbDisplay`.
+12. Non-typography primitives may set **default** typography but must not expose a
+    spread of text-treatment inputs.
+13. Component-specific behavior stays inside the primitive (anatomy, not tokens).
+14. Repeated token styling becomes an internal capability candidate.
+15. Capability directives stay internal unless there is a clear public use case.
+16. CSS variables follow `--nb-{namespace}-{property}`; color vars say `-color`.
+17. Tailwind remains the escape hatch for layout, responsiveness, positioning,
+    and recipe-specific art direction.
+18. Do not add an input only because Tailwind has an equivalent utility.
+19. Add an input only when it maps to a reusable token, primitive anatomy,
+    accessibility behavior, or a repeated brutalist composition pattern.
+20. Keep the public API aligned with **"Build loud. Stay sharp."**
+
+---
+
+```txt
+The API consistency audit defines the language.
+The capability refactor implements the language.
+Recipes prove the language works.
+```

--- a/docs/components/composition-philosophy.md
+++ b/docs/components/composition-philosophy.md
@@ -66,6 +66,19 @@ Custom expressive typography is composed:
 </button>
 ```
 
+## Component-specific CSS variables
+
+Every primitive's visual tokens resolve to a namespaced variable set
+(`--nb-surface-bg`, `--nb-button-radius`, `--nb-media-frame-shadow`, …) written
+by internal style capabilities. These are the customization/debug contract:
+inspect them in devtools, document them, and override per token. The vocabulary
+(`tone`, `radius`, `shadow`, `border`, `gap`, `padding`) is defined once in
+`libs/ui/src/lib/tokens/` so a token means the same thing across every primitive.
+See [style-capabilities.md](./style-capabilities.md) for the internal architecture.
+
+> Note: `border` means **outline strength** library-wide. Line placement between
+> layout regions is `divider` (e.g. `nbSection divider="top"`).
+
 ## Don't duplicate what a primitive already owns
 
 If `nbSurface clip` already applies `overflow: hidden`, don't add `overflow-hidden`

--- a/docs/components/style-capabilities.md
+++ b/docs/components/style-capabilities.md
@@ -1,0 +1,126 @@
+# Internal Style-Capability Architecture
+
+How ng-brutalism primitives share their visual vocabulary without duplicating
+token logic. This is an **internal** architecture note — public users keep
+composing the primitives (`nbSurface`, `nbButton`, …); they never touch the
+capability layer.
+
+## The five layers
+
+```
+tokens          libs/ui/src/lib/tokens/*        vocabulary + value resolvers
+   ↓
+DI tokens       core/capabilities/nb-style-tokens.ts   NB_STYLE_NAMESPACE / NB_STYLE_DEFAULTS
+   ↓
+capabilities    core/capabilities/*            internal directives, write --nb-<ns>-* vars
+   ↓
+primitives      lib/<primitive>/*              compose capabilities via hostDirectives
+   ↓
+CSS             primitive `classes()`          consume --nb-<ns>-* via Tailwind utilities
+```
+
+- **Tokens** define the vocabulary once: `NbRadius`, `NbShadow`,
+  `NbBorderStrength`, `NbSpacing` (gap), `NbPadding`, `NbDivider`, plus
+  `nbToneVars()`. Each file co-locates the type with its resolver
+  (`nbRadiusValue()`, …) — the single source of truth, so a token means the same
+  thing in every primitive.
+- **Capabilities** are tiny standalone directives (`NbToneCapability`,
+  `NbRadiusCapability`, …). Each injects `NB_STYLE_NAMESPACE` + `NB_STYLE_DEFAULTS`,
+  resolves its one input, and binds a **signal-driven host `[style]` map** that
+  writes namespaced component variables. No `effect()` — the dynamic variable
+  name (`--nb-${ns}-radius`) is produced by a `computed()` style map, which is
+  the declarative, zoneless-friendly idiom. Each also reflects a `data-<token>`
+  attribute for inspection.
+- **Resolution order** inside every capability:
+  `explicit input → NB_STYLE_DEFAULTS[token] → capability hard fallback`.
+- **Primitives** provide their namespace + defaults and compose the capabilities
+  through Angular `hostDirectives`, forwarding the public input names
+  (`inputs: ['tone']`). The primitive keeps only its own anatomy (Surface `clip`,
+  MediaFrame `ratio`/`fit`, Button `variant`/`size`/state, layout
+  `align`/`justify`/`divider`, …) and a Tailwind base-class string that *consumes*
+  the variables.
+
+## Component variable contract
+
+Each primitive owns a namespaced set of variables — easy to inspect, document,
+and override:
+
+| Primitive | namespace | variables written |
+|---|---|---|
+| nbSurface | `surface` | `--nb-surface-{bg,fg,border-color,radius,border-width,shadow}` |
+| nbMediaFrame | `media-frame` | `--nb-media-frame-{bg,fg,border-color,radius,border-width,shadow}` |
+| nbButton | `button` | `--nb-button-radius` (+ existing `--nb-button-{bg,fg}`) |
+| nbChip | `chip` | `--nb-chip-{bg,fg,border-color,radius,shadow}` |
+| nbCallout | `callout` | `--nb-callout-{bg,fg,border-color,shadow}` (radius is size-derived) |
+| nbSection | `section` | `--nb-section-padding` |
+| nbStack | `stack` | `--nb-stack-gap` |
+| nbCluster | `cluster` | `--nb-cluster-{gap,padding}` |
+| nbSplit | `split` | `--nb-split-{gap,padding}` |
+
+> Tone owns `bg` / `fg` / `border-color`; the border capability owns
+> `border-width` only — so color and width never fight.
+
+## Why some primitives only partially adopt capabilities
+
+- **Button** composes the **radius** capability only. Its color is a
+  `variant`(preset) + `tone`(override) hybrid layered over a `var(--nb-main)`
+  default, and `shadow` encodes hover-translate behavior — neither matches the
+  "always write a resolved value" capability contract. Its existing
+  `--nb-button-bg/-fg` bindings already satisfy the namespaced-variable goal.
+- **Callout** keeps its size-derived radius/border-width (anatomy), composing only
+  tone + shadow.
+- **Surface / Chip** keep their asymmetric padding primitive-local; only the
+  uniform-container primitives (Section / Cluster / Split) use the padding
+  capability.
+
+## Public API export policy
+
+Public: the primitives, their type aliases, and the shared token types +
+resolvers (`NbRadius`, `nbRadiusValue`, …). The capability directives and
+`NB_STYLE_*` DI tokens are exported from the package entry **only** because
+Angular requires classes referenced by `hostDirectives` to be reachable
+(NG3001); they are marked INTERNAL and are not meant for direct use.
+
+---
+
+## Migration summary
+
+### Added
+- Shared token contracts + resolvers: `NbRadius`/`nbRadiusValue`,
+  `NbShadow`/`nbShadowValue`, `NbBorderStrength`/`nbBorderWidthValue`,
+  `NbSpacing`/`nbSpacingValue`, `NbPadding`/`nbPaddingValue`, `NbDivider`, and
+  `nbToneVars()` (+ `NbToneToken` neutral aliases `surface`/`background`/`ink`).
+- Internal capabilities: `NbToneCapability`, `NbRadiusCapability`,
+  `NbShadowCapability`, `NbBorderCapability`, `NbPaddingCapability`,
+  `NbGapCapability`.
+- DI tokens: `NB_STYLE_NAMESPACE`, `NB_STYLE_DEFAULTS` (+ `NbStyleDefaults`).
+
+### Changed
+- `NbSurface`, `NbMediaFrame`, `NbButton`, `NbChip`, `NbCallout`, `NbSection`,
+  `NbStack`, `NbCluster`, `NbSplit` now compose shared capabilities via
+  `hostDirectives` instead of redefining token unions/maps.
+- Style capabilities write component-specific CSS variables (e.g.
+  `--nb-surface-bg`, `--nb-button-radius`) via host `[style]` maps; primitives
+  consume them with Tailwind utilities (no new `.nb-*` CSS classes).
+- Per-primitive token type names (`NbSurfaceRadius`, `NbButtonRadius`,
+  `NbStackGap`, …) are retained as **aliases** of the shared tokens.
+
+### Removed
+- Duplicated radius/shadow/border/gap/padding maps and tone computeds from the
+  individual primitives.
+- Drifted Surface values `radius="base"` and `shadow="lifted"`.
+
+### Public API impact
+- **Renamed (breaking):** `nbSection [border]` → `[divider]`,
+  `[borderStyle]` → `[dividerStyle]`; `NbSectionBorder` → `NbSectionDivider`,
+  `NbSectionBorderStyle` → `NbSectionDividerStyle`.
+- **Removed (breaking, pre-1.0):** Surface `radius="base"`, `shadow="lifted"`.
+- **Canonicalized values:** a token (e.g. `radius="lg"`) now resolves to one
+  geometry everywhere; primitives whose old value differed shift slightly.
+- **Unchanged:** all other primitive inputs/selectors, Button `variant`/`tone`/
+  `shadow`, and every layout primitive input.
+
+### Follow-ups
+- Revisit folding Button `tone`/`variant` into the tone capability post-1.0.
+- Consider sharing `NbDivider` placement logic across Stack/Cluster/Split dividers.
+- Optionally unify Surface/Chip padding onto the padding capability later.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -23,11 +23,11 @@ For history and details, read the domain's own `progress.md`.
 ---
 
 ## Components
-**Status:** Stabilization pass on `feat/recipes`. Added built-in accent underline to `nbDisplay`/`nbText` (`underline="bar" | "wave"`, token-driven `--nb-underline-*`, default `--nb-pink`); podcast-card recipe uses it instead of manual bar spans. Divider border color classes made explicit. `NbButton.fullWidth` uses `booleanAttribute`. `NbIcon` assigns `--nb-icon-color`. Job card recipe added (P9). All tests pass; build clean.
-**Last action:** Podcast-card recipe audit — removed duplicate `overflow-hidden` (nbSurface `clip` owns it), moved button typography to nested `nbText`, added portable `max-w-[28rem]` wrapper. Documented the ng-brutalism/`nbText`/Tailwind boundary in `docs/components/composition-philosophy.md`. Flagged `NbButton` typography inputs (`fontSize`/`transform`/`tracking`) for deprecation.
-**Next:** Visual QA pass on job card and cluster divider demos, then cut v0.2.0 release.
+**Status:** Internal style-capability refactor landed on `refactor/internal-style-capabilities`. Shared token contracts + resolvers (`NbRadius`/`NbShadow`/`NbBorderStrength`/`NbSpacing`/`NbPadding`/`NbDivider` + `nbToneVars`) feed 6 internal capability directives composed into 9 primitives via `hostDirectives`. Capabilities write component-specific CSS vars (`--nb-surface-radius`, `--nb-button-radius`, …) through signal-driven `[style]` maps (no `effect()`). Values canonicalized; duplicated maps removed. ui build + 150 tests green.
+**Last action:** Refactored Surface/MediaFrame/Button/Chip/Callout/Section/Stack/Cluster/Split. Renamed `nbSection border`→`divider` (+ `borderStyle`→`dividerStyle`); dropped Surface `radius="base"`/`shadow="lifted"`. Architecture + migration summary in `docs/components/style-capabilities.md`.
+**Next:** Build docs app + visual QA podcast-card; then resume v0.2.0 release. Follow-up: fold Button tone/variant into tone capability post-1.0.
 **Goal:** All 18 reference designs buildable with v0.2.0 primitives (~90% fidelity).
-→ Plan: `docs/release/v0.2.0-plan.md`
+→ Plan: `docs/release/v0.2.0-plan.md` · Arch: `docs/components/style-capabilities.md`
 
 ---
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -25,9 +25,9 @@ For history and details, read the domain's own `progress.md`.
 ## Components
 **Status:** Internal style-capability refactor landed on `refactor/internal-style-capabilities`. Shared token contracts + resolvers (`NbRadius`/`NbShadow`/`NbBorderStrength`/`NbSpacing`/`NbPadding`/`NbDivider` + `nbToneVars`) feed 6 internal capability directives composed into 9 primitives via `hostDirectives`. Capabilities write component-specific CSS vars (`--nb-surface-radius`, `--nb-button-radius`, …) through signal-driven `[style]` maps (no `effect()`). Values canonicalized; duplicated maps removed. ui build + 150 tests green.
 **Last action:** Refactored Surface/MediaFrame/Button/Chip/Callout/Section/Stack/Cluster/Split. Renamed `nbSection border`→`divider` (+ `borderStyle`→`dividerStyle`); dropped Surface `radius="base"`/`shadow="lifted"`. Architecture + migration summary in `docs/components/style-capabilities.md`.
-**Next:** Build docs app + visual QA podcast-card; then resume v0.2.0 release. Follow-up: fold Button tone/variant into tone capability post-1.0.
+**Next:** API consistency audit landed (`docs/architecture/api-consistency-audit.md`) — next capability-adoption wave: resolve `divider` collision (Section placement vs layout line-style), rename `size="default"`→`"md"`, move Button typography→`nbText`, widen tone/border capability to IconButton/MediaItem/Chip, kill MediaItem hex map + `NbIconButtonRadius`. Then docs app build + visual QA podcast-card; resume v0.2.0. Post-1.0: fold Button variant into tone.
 **Goal:** All 18 reference designs buildable with v0.2.0 primitives (~90% fidelity).
-→ Plan: `docs/release/v0.2.0-plan.md` · Arch: `docs/components/style-capabilities.md`
+→ Plan: `docs/release/v0.2.0-plan.md` · Arch: `docs/components/style-capabilities.md` · Audit: `docs/architecture/api-consistency-audit.md`
 
 ---
 

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -4,7 +4,37 @@ export { provideNgBrutalism } from './lib/core/provide';
 export type { NbConfig } from './lib/core/provide';
 export { NB_THEME_CONFIG } from './lib/tokens/theme.tokens';
 export type { NbThemeConfig } from './lib/tokens/theme.tokens';
-export type { NbTone, NbToneTokens } from './lib/tokens/tone';
+export type { NbTone, NbToneTokens, NbToneToken, NbToneVars } from './lib/tokens/tone';
+export { nbToneTokens, nbToneVars } from './lib/tokens/tone';
+
+// Shared design tokens — one vocabulary for every primitive's visual grammar.
+export type { NbRadius } from './lib/tokens/radius';
+export { nbRadiusValue } from './lib/tokens/radius';
+export type { NbShadow } from './lib/tokens/shadow';
+export { nbShadowValue } from './lib/tokens/shadow';
+export type { NbBorderStrength } from './lib/tokens/border';
+export { nbBorderWidthValue } from './lib/tokens/border';
+export type { NbSpacing } from './lib/tokens/spacing';
+export { nbSpacingValue } from './lib/tokens/spacing';
+export type { NbPadding } from './lib/tokens/padding';
+export { nbPaddingValue } from './lib/tokens/padding';
+export type { NbDivider } from './lib/tokens/divider';
+
+// INTERNAL — exported only because Angular requires classes referenced by
+// `hostDirectives` to be reachable from the package entrypoint (NG3001). These
+// are an internal composition mechanism: compose the public primitives
+// (nbSurface, nbButton, …) instead of applying these capabilities directly.
+export {
+  NbToneCapability,
+  NbRadiusCapability,
+  NbShadowCapability,
+  NbBorderCapability,
+  NbPaddingCapability,
+  NbGapCapability,
+  NB_STYLE_NAMESPACE,
+  NB_STYLE_DEFAULTS,
+  type NbStyleDefaults,
+} from './lib/core/capabilities';
 
 // Components
 export { NbCheckbox } from './lib/checkbox';
@@ -140,8 +170,8 @@ export type {
 export { NbSection } from './lib/section';
 export type {
   NbSectionAlign,
-  NbSectionBorder,
-  NbSectionBorderStyle,
+  NbSectionDivider,
+  NbSectionDividerStyle,
   NbSectionLayout,
   NbSectionPadding,
 } from './lib/section';

--- a/libs/ui/src/lib/button/button.tokens.spec.ts
+++ b/libs/ui/src/lib/button/button.tokens.spec.ts
@@ -57,7 +57,10 @@ describe('NbButton token surface', () => {
     expect(cls).toContain(
       '[--nb-button-border-width:var(--nb-border-width)]'
     );
-    expect(cls).toContain('[--nb-button-radius:var(--nb-radius)]');
+    // Radius is now written as a component variable by the radius capability.
+    expect(button.style.getPropertyValue('--nb-button-radius')).toBe(
+      'var(--nb-radius)'
+    );
     expect(cls).toContain(
       '[--nb-button-shadow:var(--nb-shadow-offset-x)_var(--nb-shadow-offset-y)_0_var(--nb-shadow)]'
     );

--- a/libs/ui/src/lib/button/button.types.ts
+++ b/libs/ui/src/lib/button/button.types.ts
@@ -1,3 +1,4 @@
+import type { NbRadius } from '../tokens/radius';
 import type { NbTone } from '../tokens/tone';
 
 export type NbButtonTone = NbTone;
@@ -18,7 +19,7 @@ export type NbButtonSize = 'sm' | 'md' | 'lg' | 'xl';
 
 export type NbButtonFontSize = 'sm' | 'base' | 'lg' | 'xl' | '2xl' | '3xl';
 
-export type NbButtonRadius = 'none' | 'sm' | 'md' | 'lg' | 'xl' | 'full';
+export type NbButtonRadius = NbRadius;
 
 export type NbButtonWeight = 'bold' | 'extrabold' | 'black';
 

--- a/libs/ui/src/lib/button/nb-button.ts
+++ b/libs/ui/src/lib/button/nb-button.ts
@@ -1,10 +1,15 @@
 import { Directive, booleanAttribute, computed, input } from '@angular/core';
 
 import { nbClass } from '../core/class';
+import {
+  NbRadiusCapability,
+  NB_STYLE_DEFAULTS,
+  NB_STYLE_NAMESPACE,
+  type NbStyleDefaults,
+} from '../core/capabilities';
 import { nbToneTokens } from '../tokens/tone';
 import type {
   NbButtonFontSize,
-  NbButtonRadius,
   NbButtonShadow,
   NbButtonSize,
   NbButtonTone,
@@ -32,15 +37,6 @@ const fontSizeMap: Record<NbButtonFontSize, string> = {
   '3xl': 'text-3xl',
 };
 
-const radiusMap: Record<NbButtonRadius, string> = {
-  none: '0',
-  sm: '0.25rem',
-  md: '0.5rem',
-  lg: '0.75rem',
-  xl: '1rem',
-  full: '999px',
-};
-
 const weightMap: Record<NbButtonWeight, string> = {
   bold: 'font-bold',
   extrabold: 'font-extrabold',
@@ -60,6 +56,14 @@ const trackingMap: Record<NbButtonTracking, string> = {
 
 @Directive({
   selector: 'button[nbButton], a[nbButton]',
+  providers: [
+    { provide: NB_STYLE_NAMESPACE, useValue: 'button' },
+    {
+      provide: NB_STYLE_DEFAULTS,
+      useValue: { radius: 'md' } satisfies NbStyleDefaults,
+    },
+  ],
+  hostDirectives: [{ directive: NbRadiusCapability, inputs: ['radius'] }],
   host: {
     '[class]': 'classes()',
     '[attr.data-variant]': 'variant()',
@@ -69,7 +73,6 @@ const trackingMap: Record<NbButtonTracking, string> = {
     '[attr.data-full-width]': 'fullWidth() ? "" : null',
     '[style.--nb-button-bg]': 'toneBg()',
     '[style.--nb-button-fg]': 'toneFg()',
-    '[style.--nb-button-radius]': 'radiusStyle()',
   },
 })
 export class NbButton {
@@ -78,7 +81,6 @@ export class NbButton {
   readonly shadow = input<NbButtonShadow>('default');
   readonly size = input<NbButtonSize>('md');
   readonly fontSize = input<NbButtonFontSize | undefined>(undefined);
-  readonly radius = input<NbButtonRadius | undefined>(undefined);
   readonly weight = input<NbButtonWeight>('bold');
   readonly transform = input<NbButtonTransform>('none');
   readonly tracking = input<NbButtonTracking>('normal');
@@ -94,11 +96,6 @@ export class NbButton {
     return t !== undefined ? nbToneTokens(t).fg : null;
   });
 
-  protected readonly radiusStyle = computed(() => {
-    const r = this.radius();
-    return r !== undefined ? radiusMap[r] : null;
-  });
-
   protected readonly classes = computed(() =>
     nbClass(
       'inline-flex items-center justify-center whitespace-nowrap select-none',
@@ -106,7 +103,6 @@ export class NbButton {
       '[--nb-button-fg:var(--nb-main-foreground)]',
       '[--nb-button-border:var(--nb-border)]',
       '[--nb-button-border-width:var(--nb-border-width)]',
-      '[--nb-button-radius:var(--nb-radius)]',
       '[--nb-button-shadow:var(--nb-shadow-offset-x)_var(--nb-shadow-offset-y)_0_var(--nb-shadow)]',
       'bg-(--nb-button-bg) text-(--nb-button-fg)',
       'rounded-(--nb-button-radius)',

--- a/libs/ui/src/lib/callout/nb-callout.spec.ts
+++ b/libs/ui/src/lib/callout/nb-callout.spec.ts
@@ -48,16 +48,18 @@ describe('NbCallout', () => {
     expect(callout.className).toContain(
       'border-(length:--nb-callout-border-width)'
     );
-    expect(callout.className).toContain('border-(--nb-border)');
+    expect(callout.className).toContain('border-(--nb-callout-border-color)');
     expect(callout.className).toContain('rounded-(--nb-callout-radius)');
     expect(callout.className).toContain('shadow-[var(--nb-callout-shadow)]');
     expect(callout.className).toContain('font-black');
     expect(callout.style.getPropertyValue('--nb-callout-bg')).toBe(
       'var(--nb-yellow)'
     );
+    // Border width still derives from `size` (size lg -> 3px) via the class.
     expect(callout.className).toContain('[--nb-callout-border-width:3px]');
-    expect(callout.className).toContain(
-      '[--nb-callout-shadow:6px_6px_0_0_var(--nb-shadow)]'
+    // Shadow now comes from the shadow capability as a component variable.
+    expect(callout.style.getPropertyValue('--nb-callout-shadow')).toBe(
+      '6px 6px 0 0 var(--nb-shadow)'
     );
   });
 
@@ -78,8 +80,8 @@ describe('NbCallout', () => {
     expect(callout.className).toContain('text-5xl');
     expect(callout.className).toContain('w-full');
     expect(callout.className).toContain('justify-between');
-    expect(callout.className).toContain(
-      '[--nb-callout-shadow:var(--nb-shadow-offset-x)_var(--nb-shadow-offset-y)_0_0_var(--nb-shadow)]'
+    expect(callout.style.getPropertyValue('--nb-callout-shadow')).toBe(
+      'var(--nb-shadow-offset-x) var(--nb-shadow-offset-y) 0 0 var(--nb-shadow)'
     );
   });
 

--- a/libs/ui/src/lib/callout/nb-callout.ts
+++ b/libs/ui/src/lib/callout/nb-callout.ts
@@ -1,9 +1,17 @@
 import { Directive, computed, input } from '@angular/core';
 
 import { nbClass } from '../core/class';
-import { nbToneTokens, type NbTone } from '../tokens/tone';
+import {
+  NbShadowCapability,
+  NbToneCapability,
+  NB_STYLE_DEFAULTS,
+  NB_STYLE_NAMESPACE,
+  type NbStyleDefaults,
+} from '../core/capabilities';
+import { nbRadiusValue, type NbRadius } from '../tokens/radius';
+import type { NbToneToken } from '../tokens/tone';
 
-export type NbCalloutTone = NbTone;
+export type NbCalloutTone = NbToneToken;
 
 export type NbCalloutSize = 'sm' | 'md' | 'lg' | 'xl';
 
@@ -13,61 +21,54 @@ export type NbCalloutShadow = 'none' | 'default' | 'hard';
 
 // Optional radius override. When unset, the radius is derived from `size`
 // (larger callouts get rounder corners). Set this to opt out of that scaling.
-export type NbCalloutRadius = 'none' | 'sm' | 'md' | 'lg' | 'xl' | 'full';
-
-const radiusMap: Record<NbCalloutRadius, string> = {
-  none: '0px',
-  sm: '0.375rem',
-  md: '0.5rem',
-  lg: '0.75rem',
-  xl: '0.875rem',
-  full: '9999px',
-};
+export type NbCalloutRadius = NbRadius;
 
 @Directive({
   selector: '[nbCallout]',
+  providers: [
+    { provide: NB_STYLE_NAMESPACE, useValue: 'callout' },
+    {
+      provide: NB_STYLE_DEFAULTS,
+      useValue: { tone: 'yellow', shadow: 'hard' } satisfies NbStyleDefaults,
+    },
+  ],
+  hostDirectives: [
+    { directive: NbToneCapability, inputs: ['tone'] },
+    { directive: NbShadowCapability, inputs: ['shadow'] },
+  ],
   host: {
     '[class]': 'classes()',
     '[attr.data-nb-callout]': '""',
-    '[attr.data-tone]': 'tone()',
     '[attr.data-size]': 'size()',
     '[attr.data-layout]': 'layout()',
-    '[attr.data-shadow]': 'shadow()',
-    '[attr.data-radius]': 'radius()',
-    '[style.--nb-callout-bg]': 'toneTokens().bg',
-    '[style.--nb-callout-fg]': 'toneTokens().fg',
+    '[attr.data-radius]': 'radius() ?? null',
     '[style.--nb-callout-radius]': 'radiusStyle()',
   },
 })
 export class NbCallout {
-  readonly tone = input<NbCalloutTone>('yellow');
   readonly size = input<NbCalloutSize>('lg');
   readonly layout = input<NbCalloutLayout>('inline');
-  readonly shadow = input<NbCalloutShadow>('hard');
   readonly radius = input<NbCalloutRadius | undefined>(undefined);
 
   protected readonly classes = computed(() =>
     nbClass(
       'relative inline-flex items-center gap-3',
       'bg-(--nb-callout-bg) text-(--nb-callout-fg)',
-      'border-(length:--nb-callout-border-width) border-(--nb-border)',
+      'border-(length:--nb-callout-border-width) border-(--nb-callout-border-color)',
       'rounded-(--nb-callout-radius)',
       'shadow-[var(--nb-callout-shadow)]',
       'font-black uppercase leading-none',
       this.sizeClass(),
-      this.layoutClass(),
-      this.shadowClass()
+      this.layoutClass()
     )
   );
-
-  protected readonly toneTokens = computed(() => nbToneTokens(this.tone()));
 
   // Inline style wins over the size-derived `--nb-callout-radius` class, so an
   // explicit `radius` always takes precedence; null leaves the size default.
   protected readonly radiusStyle = computed(() => {
     const r = this.radius();
 
-    return r !== undefined ? radiusMap[r] : null;
+    return r !== undefined ? nbRadiusValue(r) : null;
   });
 
   private sizeClass(): string {
@@ -89,16 +90,5 @@ export class NbCallout {
     };
 
     return map[this.layout()];
-  }
-
-  private shadowClass(): string {
-    const map: Record<NbCalloutShadow, string> = {
-      none: '[--nb-callout-shadow:none]',
-      default:
-        '[--nb-callout-shadow:var(--nb-shadow-offset-x)_var(--nb-shadow-offset-y)_0_0_var(--nb-shadow)]',
-      hard: '[--nb-callout-shadow:6px_6px_0_0_var(--nb-shadow)]',
-    };
-
-    return map[this.shadow()];
   }
 }

--- a/libs/ui/src/lib/chip/nb-chip.ts
+++ b/libs/ui/src/lib/chip/nb-chip.ts
@@ -7,17 +7,28 @@ import {
 } from '@angular/core';
 
 import { nbClass } from '../core/class';
+import {
+  NbRadiusCapability,
+  NbShadowCapability,
+  NbToneCapability,
+  NB_STYLE_DEFAULTS,
+  NB_STYLE_NAMESPACE,
+  type NbStyleDefaults,
+} from '../core/capabilities';
 import { NbIcon, type NbIconSize } from '../icon';
-import { nbToneTokens, type NbTone } from '../tokens/tone';
+import type { NbRadius } from '../tokens/radius';
+import type { NbShadow } from '../tokens/shadow';
+import type { NbToneToken } from '../tokens/tone';
 
-export type NbChipTone = NbTone | 'ink';
-// Token scale mirrors NbSplitPadding (`none | sm | md | lg | xl`) for API
-// consistency with the layout directives. Values stay chip-specific and
-// asymmetric (horizontal > vertical) because a chip is an inline pill, not a
-// container — uniform container padding would make it a box.
+export type NbChipTone = NbToneToken;
+export type NbChipRadius = NbRadius;
+export type NbChipShadow = NbShadow;
+// Token scale mirrors the layout directives for API consistency, but values
+// stay chip-specific and asymmetric (horizontal > vertical) because a chip is
+// an inline pill, not a container — uniform container padding would make it a
+// box. Padding therefore stays primitive-local rather than using the shared
+// padding capability.
 export type NbChipPadding = 'none' | 'sm' | 'md' | 'lg' | 'xl';
-export type NbChipRadius = 'none' | 'sm' | 'md' | 'lg' | 'full';
-export type NbChipShadow = 'none' | 'sm' | 'default' | 'hard';
 
 const paddingMap: Record<NbChipPadding, string> = {
   none: 'px-0 py-0',
@@ -27,25 +38,25 @@ const paddingMap: Record<NbChipPadding, string> = {
   xl: 'px-5 py-2.5',
 };
 
-const radiusMap: Record<NbChipRadius, string> = {
-  none: '[--nb-chip-radius:0px]',
-  sm: '[--nb-chip-radius:0.375rem]',
-  md: '[--nb-chip-radius:0.5rem]',
-  lg: '[--nb-chip-radius:0.75rem]',
-  full: '[--nb-chip-radius:9999px]',
-};
-
-const shadowMap: Record<NbChipShadow, string> = {
-  none: '[--nb-chip-shadow:none]',
-  sm: '[--nb-chip-shadow:2px_2px_0_0_var(--nb-shadow)]',
-  default:
-    '[--nb-chip-shadow:var(--nb-shadow-offset-x)_var(--nb-shadow-offset-y)_0_0_var(--nb-shadow)]',
-  hard: '[--nb-chip-shadow:6px_6px_0_0_var(--nb-shadow)]',
-};
-
 @Component({
   selector: 'span[nbChip]',
   imports: [NbIcon],
+  providers: [
+    { provide: NB_STYLE_NAMESPACE, useValue: 'chip' },
+    {
+      provide: NB_STYLE_DEFAULTS,
+      useValue: {
+        tone: 'default',
+        radius: 'none',
+        shadow: 'sm',
+      } satisfies NbStyleDefaults,
+    },
+  ],
+  hostDirectives: [
+    { directive: NbToneCapability, inputs: ['tone'] },
+    { directive: NbRadiusCapability, inputs: ['radius'] },
+    { directive: NbShadowCapability, inputs: ['shadow'] },
+  ],
   template: `
     @if (icon()) {
       <span nbIcon [src]="icon()!" [size]="iconSize()" decorative></span>
@@ -54,21 +65,13 @@ const shadowMap: Record<NbChipShadow, string> = {
   `,
   host: {
     '[class]': 'classes()',
-    '[attr.data-tone]': 'tone()',
     '[attr.data-padding]': 'padding()',
-    '[attr.data-radius]': 'radius()',
-    '[attr.data-shadow]': 'shadow()',
     '[attr.data-nb-chip]': '""',
-    '[style.--nb-chip-bg]': 'toneTokens().bg',
-    '[style.--nb-chip-fg]': 'toneTokens().fg',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class NbChip {
-  readonly tone = input<NbChipTone>('default');
   readonly padding = input<NbChipPadding>('md');
-  readonly radius = input<NbChipRadius>('none');
-  readonly shadow = input<NbChipShadow>('sm');
   // Optional leading icon, given as an SVG/image URL. Rendered through nbIcon
   // in mask mode so it tints to the chip's foreground color. For full-color
   // or labeled icons, compose an `nbIcon` (or any element) as projected
@@ -79,22 +82,14 @@ export class NbChip {
   protected readonly classes = computed(() =>
     nbClass(
       'inline-flex items-center gap-1.5',
-      'border-2 border-(--nb-border)',
-      'bg-[var(--nb-chip-bg,var(--nb-surface))] text-[var(--nb-chip-fg,var(--nb-foreground))]',
+      'border-2 border-(--nb-chip-border-color)',
+      'bg-(--nb-chip-bg) text-(--nb-chip-fg)',
       'rounded-(--nb-chip-radius) shadow-[var(--nb-chip-shadow)]',
       'text-xs font-bold',
       paddingMap[this.padding()],
-      radiusMap[this.radius()],
-      shadowMap[this.shadow()],
       '[&_svg]:size-[var(--nb-chip-icon-size,0.75rem)] [&_svg]:shrink-0'
     )
   );
-
-  protected readonly toneTokens = computed(() => {
-    const tone = this.tone();
-
-    return tone === 'ink' ? nbToneTokens('black') : nbToneTokens(tone);
-  });
 }
 
 @Directive({

--- a/libs/ui/src/lib/cluster/nb-cluster.spec.ts
+++ b/libs/ui/src/lib/cluster/nb-cluster.spec.ts
@@ -66,7 +66,7 @@ describe('NbCluster', () => {
     expect(cluster.className).toContain('flex');
     expect(cluster.className).toContain('min-w-0');
     expect(cluster.className).toContain('gap-[var(--nb-cluster-gap)]');
-    expect(cluster.className).toContain('[--nb-cluster-gap:0.75rem]');
+    expect(cluster.style.getPropertyValue('--nb-cluster-gap')).toBe('0.75rem');
     expect(cluster.className).toContain('items-center');
     expect(cluster.className).toContain('justify-start');
     expect(cluster.className).toContain('flex-wrap');
@@ -88,7 +88,7 @@ describe('NbCluster', () => {
     expect(cluster.getAttribute('data-divider')).toBe('dashed');
     expect(cluster.className).toContain('gap-y-[var(--nb-cluster-gap)]');
     expect(cluster.className).toContain('gap-x-0');
-    expect(cluster.className).toContain('[--nb-cluster-gap:1rem]');
+    expect(cluster.style.getPropertyValue('--nb-cluster-gap')).toBe('1rem');
     expect(cluster.className).toContain(
       '[--nb-cluster-divider-gap:calc(var(--nb-cluster-gap)*0.5)]'
     );
@@ -135,7 +135,8 @@ describe('NbCluster', () => {
     const cluster = fixture.nativeElement.querySelector('[nbCluster]') as HTMLElement;
 
     expect(cluster.getAttribute('data-padding')).toBe('lg');
-    expect(cluster.className).toContain('p-6');
+    expect(cluster.className).toContain('p-[var(--nb-cluster-padding)]');
+    expect(cluster.style.getPropertyValue('--nb-cluster-padding')).toBe('1.5rem');
   });
 
   it('maps gap, alignment, justification, and wrapping', async () => {
@@ -148,7 +149,7 @@ describe('NbCluster', () => {
     expect(cluster.getAttribute('data-align')).toBe('baseline');
     expect(cluster.getAttribute('data-justify')).toBe('between');
     expect(cluster.getAttribute('data-wrap')).toBe('nowrap');
-    expect(cluster.className).toContain('[--nb-cluster-gap:1.5rem]');
+    expect(cluster.style.getPropertyValue('--nb-cluster-gap')).toBe('1.5rem');
     expect(cluster.className).toContain('items-baseline');
     expect(cluster.className).toContain('justify-between');
     expect(cluster.className).toContain('flex-nowrap');

--- a/libs/ui/src/lib/cluster/nb-cluster.ts
+++ b/libs/ui/src/lib/cluster/nb-cluster.ts
@@ -1,10 +1,19 @@
 import { Directive, computed, input } from '@angular/core';
 
 import { nbClass } from '../core/class';
+import {
+  NbGapCapability,
+  NbPaddingCapability,
+  NB_STYLE_DEFAULTS,
+  NB_STYLE_NAMESPACE,
+  type NbStyleDefaults,
+} from '../core/capabilities';
+import type { NbPadding } from '../tokens/padding';
+import type { NbSpacing } from '../tokens/spacing';
 
-export type NbClusterGap = 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+export type NbClusterGap = NbSpacing;
 
-export type NbClusterPadding = 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+export type NbClusterPadding = NbPadding;
 
 export type NbClusterAlign =
   | 'start'
@@ -21,11 +30,20 @@ export type NbClusterDivider = 'none' | 'solid' | 'dashed' | 'thick';
 
 @Directive({
   selector: '[nbCluster]',
+  providers: [
+    { provide: NB_STYLE_NAMESPACE, useValue: 'cluster' },
+    {
+      provide: NB_STYLE_DEFAULTS,
+      useValue: { gap: 'md', padding: 'none' } satisfies NbStyleDefaults,
+    },
+  ],
+  hostDirectives: [
+    { directive: NbGapCapability, inputs: ['gap'] },
+    { directive: NbPaddingCapability, inputs: ['padding'] },
+  ],
   host: {
     '[class]': 'classes()',
     '[attr.data-nb-cluster]': '""',
-    '[attr.data-gap]': 'gap()',
-    '[attr.data-padding]': 'padding()',
     '[attr.data-align]': 'align()',
     '[attr.data-justify]': 'justify()',
     '[attr.data-wrap]': 'wrap()',
@@ -33,8 +51,6 @@ export type NbClusterDivider = 'none' | 'solid' | 'dashed' | 'thick';
   },
 })
 export class NbCluster {
-  readonly gap = input<NbClusterGap>('md');
-  readonly padding = input<NbClusterPadding>('none');
   readonly align = input<NbClusterAlign>('center');
   readonly justify = input<NbClusterJustify>('start');
   readonly wrap = input<NbClusterWrap>('wrap');
@@ -43,8 +59,8 @@ export class NbCluster {
   protected readonly classes = computed(() =>
     nbClass(
       'flex min-w-0',
+      'p-[var(--nb-cluster-padding)]',
       this.gapClass(),
-      this.paddingClass(),
       this.alignClass(),
       this.justifyClass(),
       this.wrapClass(),
@@ -53,34 +69,13 @@ export class NbCluster {
   );
 
   private gapClass(): string {
-    const map: Record<NbClusterGap, string> = {
-      none: '[--nb-cluster-gap:0px]',
-      xs: '[--nb-cluster-gap:0.25rem]',
-      sm: '[--nb-cluster-gap:0.5rem]',
-      md: '[--nb-cluster-gap:0.75rem]',
-      lg: '[--nb-cluster-gap:1rem]',
-      xl: '[--nb-cluster-gap:1.5rem]',
-      '2xl': '[--nb-cluster-gap:2rem]',
-    };
-
+    // With a divider, gap collapses on the inline axis (the divider owns the
+    // inline spacing) and survives only on the block axis for wrapped rows.
     if (this.divider() !== 'none') {
-      return nbClass(map[this.gap()], 'gap-y-[var(--nb-cluster-gap)]', 'gap-x-0');
+      return 'gap-y-[var(--nb-cluster-gap)] gap-x-0';
     }
 
-    return nbClass(map[this.gap()], 'gap-[var(--nb-cluster-gap)]');
-  }
-
-  private paddingClass(): string {
-    const map: Record<NbClusterPadding, string> = {
-      none: '',
-      xs: 'p-2',
-      sm: 'p-3',
-      md: 'p-4',
-      lg: 'p-6',
-      xl: 'p-8',
-    };
-
-    return map[this.padding()];
+    return 'gap-[var(--nb-cluster-gap)]';
   }
 
   private alignClass(): string {

--- a/libs/ui/src/lib/core/capabilities/index.ts
+++ b/libs/ui/src/lib/core/capabilities/index.ts
@@ -1,0 +1,14 @@
+// INTERNAL barrel. Consumed by library primitives only — NOT re-exported from
+// the package entry point (`libs/ui/src/index.ts`). Capability directives are an
+// internal composition mechanism; users compose the public primitives instead.
+export {
+  NB_STYLE_DEFAULTS,
+  NB_STYLE_NAMESPACE,
+  type NbStyleDefaults,
+} from './nb-style-tokens';
+export { NbToneCapability } from './nb-tone-capability';
+export { NbRadiusCapability } from './nb-radius-capability';
+export { NbShadowCapability } from './nb-shadow-capability';
+export { NbBorderCapability } from './nb-border-capability';
+export { NbPaddingCapability } from './nb-padding-capability';
+export { NbGapCapability } from './nb-gap-capability';

--- a/libs/ui/src/lib/core/capabilities/nb-border-capability.ts
+++ b/libs/ui/src/lib/core/capabilities/nb-border-capability.ts
@@ -1,0 +1,30 @@
+import { Directive, computed, inject, input } from '@angular/core';
+
+import { nbBorderWidthValue, type NbBorderStrength } from '../../tokens/border';
+import { NB_STYLE_DEFAULTS, NB_STYLE_NAMESPACE } from './nb-style-tokens';
+
+/**
+ * INTERNAL capability — not part of the public API. Writes
+ * `--nb-<ns>-border-width` only; border color is owned by the tone capability.
+ */
+@Directive({
+  selector: '[nbBorderCapability]',
+  host: {
+    '[style]': 'styleVars()',
+    '[attr.data-border]': 'resolved()',
+  },
+})
+export class NbBorderCapability {
+  private readonly namespace = inject(NB_STYLE_NAMESPACE);
+  private readonly defaults = inject(NB_STYLE_DEFAULTS);
+
+  readonly border = input<NbBorderStrength | undefined>(undefined);
+
+  protected readonly resolved = computed(
+    () => this.border() ?? this.defaults.border ?? 'default',
+  );
+
+  protected readonly styleVars = computed(() => ({
+    [`--nb-${this.namespace}-border-width`]: nbBorderWidthValue(this.resolved()),
+  }));
+}

--- a/libs/ui/src/lib/core/capabilities/nb-gap-capability.ts
+++ b/libs/ui/src/lib/core/capabilities/nb-gap-capability.ts
@@ -1,0 +1,30 @@
+import { Directive, computed, inject, input } from '@angular/core';
+
+import { nbSpacingValue, type NbSpacing } from '../../tokens/spacing';
+import { NB_STYLE_DEFAULTS, NB_STYLE_NAMESPACE } from './nb-style-tokens';
+
+/**
+ * INTERNAL capability — not part of the public API. Writes `--nb-<ns>-gap` for
+ * layout primitives (nbStack / nbCluster / nbSplit).
+ */
+@Directive({
+  selector: '[nbGapCapability]',
+  host: {
+    '[style]': 'styleVars()',
+    '[attr.data-gap]': 'resolved()',
+  },
+})
+export class NbGapCapability {
+  private readonly namespace = inject(NB_STYLE_NAMESPACE);
+  private readonly defaults = inject(NB_STYLE_DEFAULTS);
+
+  readonly gap = input<NbSpacing | undefined>(undefined);
+
+  protected readonly resolved = computed(
+    () => this.gap() ?? this.defaults.gap ?? 'md',
+  );
+
+  protected readonly styleVars = computed(() => ({
+    [`--nb-${this.namespace}-gap`]: nbSpacingValue(this.resolved()),
+  }));
+}

--- a/libs/ui/src/lib/core/capabilities/nb-padding-capability.ts
+++ b/libs/ui/src/lib/core/capabilities/nb-padding-capability.ts
@@ -1,0 +1,30 @@
+import { Directive, computed, inject, input } from '@angular/core';
+
+import { nbPaddingValue, type NbPadding } from '../../tokens/padding';
+import { NB_STYLE_DEFAULTS, NB_STYLE_NAMESPACE } from './nb-style-tokens';
+
+/**
+ * INTERNAL capability — not part of the public API. Writes `--nb-<ns>-padding`.
+ * Use only on primitives that own uniform container padding.
+ */
+@Directive({
+  selector: '[nbPaddingCapability]',
+  host: {
+    '[style]': 'styleVars()',
+    '[attr.data-padding]': 'resolved()',
+  },
+})
+export class NbPaddingCapability {
+  private readonly namespace = inject(NB_STYLE_NAMESPACE);
+  private readonly defaults = inject(NB_STYLE_DEFAULTS);
+
+  readonly padding = input<NbPadding | undefined>(undefined);
+
+  protected readonly resolved = computed(
+    () => this.padding() ?? this.defaults.padding ?? 'md',
+  );
+
+  protected readonly styleVars = computed(() => ({
+    [`--nb-${this.namespace}-padding`]: nbPaddingValue(this.resolved()),
+  }));
+}

--- a/libs/ui/src/lib/core/capabilities/nb-radius-capability.ts
+++ b/libs/ui/src/lib/core/capabilities/nb-radius-capability.ts
@@ -1,0 +1,29 @@
+import { Directive, computed, inject, input } from '@angular/core';
+
+import { nbRadiusValue, type NbRadius } from '../../tokens/radius';
+import { NB_STYLE_DEFAULTS, NB_STYLE_NAMESPACE } from './nb-style-tokens';
+
+/**
+ * INTERNAL capability — not part of the public API. Writes `--nb-<ns>-radius`.
+ */
+@Directive({
+  selector: '[nbRadiusCapability]',
+  host: {
+    '[style]': 'styleVars()',
+    '[attr.data-radius]': 'resolved()',
+  },
+})
+export class NbRadiusCapability {
+  private readonly namespace = inject(NB_STYLE_NAMESPACE);
+  private readonly defaults = inject(NB_STYLE_DEFAULTS);
+
+  readonly radius = input<NbRadius | undefined>(undefined);
+
+  protected readonly resolved = computed(
+    () => this.radius() ?? this.defaults.radius ?? 'md',
+  );
+
+  protected readonly styleVars = computed(() => ({
+    [`--nb-${this.namespace}-radius`]: nbRadiusValue(this.resolved()),
+  }));
+}

--- a/libs/ui/src/lib/core/capabilities/nb-shadow-capability.ts
+++ b/libs/ui/src/lib/core/capabilities/nb-shadow-capability.ts
@@ -1,0 +1,29 @@
+import { Directive, computed, inject, input } from '@angular/core';
+
+import { nbShadowValue, type NbShadow } from '../../tokens/shadow';
+import { NB_STYLE_DEFAULTS, NB_STYLE_NAMESPACE } from './nb-style-tokens';
+
+/**
+ * INTERNAL capability — not part of the public API. Writes `--nb-<ns>-shadow`.
+ */
+@Directive({
+  selector: '[nbShadowCapability]',
+  host: {
+    '[style]': 'styleVars()',
+    '[attr.data-shadow]': 'resolved()',
+  },
+})
+export class NbShadowCapability {
+  private readonly namespace = inject(NB_STYLE_NAMESPACE);
+  private readonly defaults = inject(NB_STYLE_DEFAULTS);
+
+  readonly shadow = input<NbShadow | undefined>(undefined);
+
+  protected readonly resolved = computed(
+    () => this.shadow() ?? this.defaults.shadow ?? 'default',
+  );
+
+  protected readonly styleVars = computed(() => ({
+    [`--nb-${this.namespace}-shadow`]: nbShadowValue(this.resolved()),
+  }));
+}

--- a/libs/ui/src/lib/core/capabilities/nb-style-capabilities.spec.ts
+++ b/libs/ui/src/lib/core/capabilities/nb-style-capabilities.spec.ts
@@ -1,0 +1,99 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, expect, it } from 'vitest';
+
+import { NbButton } from '../../button';
+import { NbMediaFrame } from '../../media-frame';
+import { NbStack } from '../../stack';
+import { NbSurface } from '../../surface';
+
+function mount<T>(type: new () => T): HTMLElement {
+  const fixture: ComponentFixture<T> = TestBed.createComponent(type);
+  fixture.detectChanges();
+  return fixture.nativeElement as HTMLElement;
+}
+
+@Component({
+  imports: [NbSurface],
+  template: `<div nbSurface tone="mint" radius="xl">Loud</div>`,
+})
+class SurfaceExplicitTest {}
+
+@Component({
+  imports: [NbSurface],
+  template: `<div nbSurface>Defaults</div>`,
+})
+class SurfaceDefaultsTest {}
+
+@Component({
+  imports: [NbButton],
+  template: `<button nbButton tone="lavender">Listen</button>`,
+})
+class ButtonToneTest {}
+
+@Component({
+  imports: [NbMediaFrame],
+  template: `<div nbMediaFrame shadow="hard"></div>`,
+})
+class MediaFrameTest {}
+
+@Component({
+  imports: [NbStack],
+  template: `<div nbStack gap="lg"></div>`,
+})
+class StackTest {}
+
+describe('style capabilities', () => {
+  it('nbSurface writes namespaced radius + tone variables from explicit inputs', () => {
+    const el = mount(SurfaceExplicitTest);
+    const surface = el.querySelector<HTMLElement>('[nbSurface]')!;
+
+    expect(surface.style.getPropertyValue('--nb-surface-radius')).toBe('1.5rem');
+    expect(surface.style.getPropertyValue('--nb-surface-bg')).toBe(
+      'var(--nb-mint)'
+    );
+    expect(surface.style.getPropertyValue('--nb-surface-fg')).toBe('#000000');
+    expect(surface.style.getPropertyValue('--nb-surface-border-color')).toBe(
+      'var(--nb-border)'
+    );
+  });
+
+  it('nbSurface applies primitive defaults when inputs are omitted', () => {
+    const el = mount(SurfaceDefaultsTest);
+    const surface = el.querySelector<HTMLElement>('[nbSurface]')!;
+
+    // default radius 'md' -> var(--nb-radius); default border 'default' -> var(--nb-border-width)
+    expect(surface.style.getPropertyValue('--nb-surface-radius')).toBe(
+      'var(--nb-radius)'
+    );
+    expect(surface.style.getPropertyValue('--nb-surface-border-width')).toBe(
+      'var(--nb-border-width)'
+    );
+  });
+
+  it('nbButton tone writes --nb-button-bg, not --nb-surface-bg', () => {
+    const el = mount(ButtonToneTest);
+    const button = el.querySelector<HTMLElement>('[nbButton]')!;
+
+    expect(button.style.getPropertyValue('--nb-button-bg')).toBe(
+      'var(--nb-lavender)'
+    );
+    expect(button.style.getPropertyValue('--nb-surface-bg')).toBe('');
+  });
+
+  it('nbMediaFrame shadow writes namespaced --nb-media-frame-shadow', () => {
+    const el = mount(MediaFrameTest);
+    const frame = el.querySelector<HTMLElement>('[nbMediaFrame]')!;
+
+    expect(frame.style.getPropertyValue('--nb-media-frame-shadow')).toBe(
+      '6px 6px 0 0 var(--nb-shadow)'
+    );
+  });
+
+  it('nbStack gap writes --nb-stack-gap', () => {
+    const el = mount(StackTest);
+    const stack = el.querySelector<HTMLElement>('[nbStack]')!;
+
+    expect(stack.style.getPropertyValue('--nb-stack-gap')).toBe('1rem');
+  });
+});

--- a/libs/ui/src/lib/core/capabilities/nb-style-tokens.ts
+++ b/libs/ui/src/lib/core/capabilities/nb-style-tokens.ts
@@ -1,0 +1,35 @@
+import { InjectionToken } from '@angular/core';
+
+import type { NbBorderStrength } from '../../tokens/border';
+import type { NbPadding } from '../../tokens/padding';
+import type { NbRadius } from '../../tokens/radius';
+import type { NbShadow } from '../../tokens/shadow';
+import type { NbSpacing } from '../../tokens/spacing';
+import type { NbToneToken } from '../../tokens/tone';
+
+/**
+ * INTERNAL. The CSS-variable namespace a primitive owns, e.g. `'surface'` →
+ * capabilities write `--nb-surface-*`. Every primitive that composes a style
+ * capability must provide this on its element injector.
+ */
+export const NB_STYLE_NAMESPACE = new InjectionToken<string>(
+  'NB_STYLE_NAMESPACE',
+);
+
+/**
+ * INTERNAL. Per-primitive default tokens. A capability resolves its value as:
+ * explicit input → this default → the capability's own hard fallback.
+ */
+export interface NbStyleDefaults {
+  tone?: NbToneToken;
+  radius?: NbRadius;
+  shadow?: NbShadow;
+  border?: NbBorderStrength;
+  padding?: NbPadding;
+  gap?: NbSpacing;
+}
+
+export const NB_STYLE_DEFAULTS = new InjectionToken<NbStyleDefaults>(
+  'NB_STYLE_DEFAULTS',
+  { factory: () => ({}) },
+);

--- a/libs/ui/src/lib/core/capabilities/nb-tone-capability.ts
+++ b/libs/ui/src/lib/core/capabilities/nb-tone-capability.ts
@@ -1,0 +1,38 @@
+import { Directive, computed, inject, input } from '@angular/core';
+
+import { nbToneVars, type NbToneToken } from '../../tokens/tone';
+import { NB_STYLE_DEFAULTS, NB_STYLE_NAMESPACE } from './nb-style-tokens';
+
+/**
+ * INTERNAL capability — not part of the public API. Composed into primitives via
+ * `hostDirectives`. Writes the namespaced tone variables `--nb-<ns>-bg`,
+ * `--nb-<ns>-fg`, and `--nb-<ns>-border-color` from a shared tone resolver.
+ */
+@Directive({
+  selector: '[nbToneCapability]',
+  host: {
+    '[style]': 'styleVars()',
+    '[attr.data-tone]': 'resolved()',
+  },
+})
+export class NbToneCapability {
+  private readonly namespace = inject(NB_STYLE_NAMESPACE);
+  private readonly defaults = inject(NB_STYLE_DEFAULTS);
+
+  readonly tone = input<NbToneToken | undefined>(undefined);
+
+  protected readonly resolved = computed(
+    () => this.tone() ?? this.defaults.tone ?? 'default',
+  );
+
+  protected readonly styleVars = computed(() => {
+    const ns = this.namespace;
+    const vars = nbToneVars(this.resolved());
+
+    return {
+      [`--nb-${ns}-bg`]: vars.bg,
+      [`--nb-${ns}-fg`]: vars.fg,
+      [`--nb-${ns}-border-color`]: vars.borderColor,
+    };
+  });
+}

--- a/libs/ui/src/lib/media-frame/nb-media-frame.spec.ts
+++ b/libs/ui/src/lib/media-frame/nb-media-frame.spec.ts
@@ -71,8 +71,8 @@ describe('NbMediaFrame', () => {
     expect(frame.style.getPropertyValue('--nb-media-frame-bg')).toBe(
       'var(--nb-surface)'
     );
-    expect(frame.className).toContain('[--nb-media-frame-radius:1rem]');
-    expect(frame.className).toContain('[--nb-media-frame-shadow:none]');
+    expect(frame.style.getPropertyValue('--nb-media-frame-radius')).toBe('1rem');
+    expect(frame.style.getPropertyValue('--nb-media-frame-shadow')).toBe('none');
   });
 
   it('maps tone, ratio, fit, radius, and shadow attributes', async () => {
@@ -92,11 +92,13 @@ describe('NbMediaFrame', () => {
     );
     expect(frame.className).toContain('aspect-[21/9]');
     expect(frame.className).toContain('[&>video]:object-contain');
-    expect(frame.className).toContain('[--nb-media-frame-radius:1.5rem]');
-    expect(frame.className).toContain(
-      '[--nb-media-frame-shadow:6px_6px_0_0_var(--nb-shadow)]'
+    expect(frame.style.getPropertyValue('--nb-media-frame-radius')).toBe('1.5rem');
+    expect(frame.style.getPropertyValue('--nb-media-frame-shadow')).toBe(
+      '6px 6px 0 0 var(--nb-shadow)'
     );
-    expect(frame.className).toContain('[--nb-media-frame-border-width:3px]');
+    expect(frame.style.getPropertyValue('--nb-media-frame-border-width')).toBe(
+      '3px'
+    );
   });
 
   it.each([

--- a/libs/ui/src/lib/media-frame/nb-media-frame.ts
+++ b/libs/ui/src/lib/media-frame/nb-media-frame.ts
@@ -1,10 +1,27 @@
 import { Directive, computed, input } from '@angular/core';
 
 import { nbClass } from '../core/class';
-import { nbToneTokens, type NbTone } from '../tokens/tone';
+import {
+  NbBorderCapability,
+  NbRadiusCapability,
+  NbShadowCapability,
+  NbToneCapability,
+  NB_STYLE_DEFAULTS,
+  NB_STYLE_NAMESPACE,
+  type NbStyleDefaults,
+} from '../core/capabilities';
+import type { NbBorderStrength } from '../tokens/border';
+import type { NbRadius } from '../tokens/radius';
+import type { NbShadow } from '../tokens/shadow';
+import type { NbToneToken } from '../tokens/tone';
 
-export type NbMediaFrameTone = NbTone;
+// Public type aliases point at the shared token contracts.
+export type NbMediaFrameTone = NbToneToken;
+export type NbMediaFrameRadius = NbRadius;
+export type NbMediaFrameShadow = NbShadow;
+export type NbMediaFrameBorder = NbBorderStrength;
 
+// Media-frame-specific anatomy.
 export type NbMediaFrameRatio =
   | 'auto'
   | '1/1'
@@ -15,39 +32,41 @@ export type NbMediaFrameRatio =
 
 export type NbMediaFrameFit = 'cover' | 'contain' | 'fill';
 
-export type NbMediaFrameRadius = 'none' | 'sm' | 'md' | 'lg' | 'xl' | 'full';
-
-export type NbMediaFrameShadow = 'none' | 'default' | 'hard';
-
-export type NbMediaFrameBorder = 'none' | 'default' | 'strong';
-
 @Directive({
   selector: '[nbMediaFrame]',
+  providers: [
+    { provide: NB_STYLE_NAMESPACE, useValue: 'media-frame' },
+    {
+      provide: NB_STYLE_DEFAULTS,
+      useValue: {
+        tone: 'default',
+        radius: 'lg',
+        shadow: 'none',
+        border: 'default',
+      } satisfies NbStyleDefaults,
+    },
+  ],
+  hostDirectives: [
+    { directive: NbToneCapability, inputs: ['tone'] },
+    { directive: NbRadiusCapability, inputs: ['radius'] },
+    { directive: NbShadowCapability, inputs: ['shadow'] },
+    { directive: NbBorderCapability, inputs: ['border'] },
+  ],
   host: {
     '[class]': 'classes()',
     '[attr.data-nb-media-frame]': '""',
-    '[attr.data-tone]': 'tone()',
     '[attr.data-ratio]': 'ratio()',
     '[attr.data-fit]': 'fit()',
-    '[attr.data-radius]': 'radius()',
-    '[attr.data-shadow]': 'shadow()',
-    '[attr.data-border]': 'border()',
-    '[style.--nb-media-frame-bg]': 'toneTokens().bg',
-    '[style.--nb-media-frame-fg]': 'toneTokens().fg',
   },
 })
 export class NbMediaFrame {
-  readonly tone = input<NbMediaFrameTone>('default');
   readonly ratio = input<NbMediaFrameRatio>('auto');
   readonly fit = input<NbMediaFrameFit>('cover');
-  readonly radius = input<NbMediaFrameRadius>('lg');
-  readonly shadow = input<NbMediaFrameShadow>('none');
-  readonly border = input<NbMediaFrameBorder>('default');
 
   protected readonly classes = computed(() =>
     nbClass(
       'relative isolate block overflow-hidden',
-      'border-(length:--nb-media-frame-border-width) border-(--nb-border)',
+      'border-(length:--nb-media-frame-border-width) border-(--nb-media-frame-border-color)',
       'bg-(--nb-media-frame-bg) text-(--nb-media-frame-fg)',
       'rounded-(--nb-media-frame-radius)',
       'shadow-[var(--nb-media-frame-shadow)]',
@@ -56,14 +75,9 @@ export class NbMediaFrame {
       '[&>picture]:block [&>picture]:h-full [&>picture]:w-full',
       '[&>picture>img]:h-full [&>picture>img]:w-full',
       this.ratioClass(),
-      this.fitClass(),
-      this.radiusClass(),
-      this.shadowClass(),
-      this.borderClass()
+      this.fitClass()
     )
   );
-
-  protected readonly toneTokens = computed(() => nbToneTokens(this.tone()));
 
   private ratioClass(): string {
     const map: Record<NbMediaFrameRatio, string> = {
@@ -84,44 +98,9 @@ export class NbMediaFrame {
         '[&>img]:object-cover [&>video]:object-cover [&>picture>img]:object-cover',
       contain:
         '[&>img]:object-contain [&>video]:object-contain [&>picture>img]:object-contain',
-      fill:
-        '[&>img]:object-fill [&>video]:object-fill [&>picture>img]:object-fill',
+      fill: '[&>img]:object-fill [&>video]:object-fill [&>picture>img]:object-fill',
     };
 
     return map[this.fit()];
-  }
-
-  private radiusClass(): string {
-    const map: Record<NbMediaFrameRadius, string> = {
-      none: '[--nb-media-frame-radius:0px]',
-      sm: '[--nb-media-frame-radius:0.375rem]',
-      md: '[--nb-media-frame-radius:var(--nb-radius)]',
-      lg: '[--nb-media-frame-radius:1rem]',
-      xl: '[--nb-media-frame-radius:1.5rem]',
-      full: '[--nb-media-frame-radius:9999px]',
-    };
-
-    return map[this.radius()];
-  }
-
-  private shadowClass(): string {
-    const map: Record<NbMediaFrameShadow, string> = {
-      none: '[--nb-media-frame-shadow:none]',
-      default:
-        '[--nb-media-frame-shadow:var(--nb-shadow-offset-x)_var(--nb-shadow-offset-y)_0_0_var(--nb-shadow)]',
-      hard: '[--nb-media-frame-shadow:6px_6px_0_0_var(--nb-shadow)]',
-    };
-
-    return map[this.shadow()];
-  }
-
-  private borderClass(): string {
-    const map: Record<NbMediaFrameBorder, string> = {
-      none: '[--nb-media-frame-border-width:0px]',
-      default: '[--nb-media-frame-border-width:var(--nb-border-width)]',
-      strong: '[--nb-media-frame-border-width:3px]',
-    };
-
-    return map[this.border()];
   }
 }

--- a/libs/ui/src/lib/media-item/nb-media-item.spec.ts
+++ b/libs/ui/src/lib/media-item/nb-media-item.spec.ts
@@ -14,7 +14,7 @@ import {
   imports: [NbMediaItem, NbMediaItemTitle, NbMediaItemDescription, NbSurface],
   template: `
     <div nbMediaItem variant="plain" size="md">
-      <span nbSurface tone="yellow" radius="base" shadow="none" size="lg" layout="center">
+      <span nbSurface tone="yellow" radius="sm" shadow="none" size="lg" layout="center">
         <img src="/icons/calendar.png" alt="Date" />
       </span>
       <div>

--- a/libs/ui/src/lib/section/index.ts
+++ b/libs/ui/src/lib/section/index.ts
@@ -2,8 +2,8 @@ export { NbSection } from './nb-section';
 
 export type {
   NbSectionAlign,
-  NbSectionBorder,
-  NbSectionBorderStyle,
+  NbSectionDivider,
+  NbSectionDividerStyle,
   NbSectionLayout,
   NbSectionPadding,
 } from './nb-section';

--- a/libs/ui/src/lib/section/nb-section.spec.ts
+++ b/libs/ui/src/lib/section/nb-section.spec.ts
@@ -13,17 +13,17 @@ class DefaultSectionTest {}
 @Component({
   imports: [NbSection],
   template: `
-    <div nbSection padding="lg" border="top">
+    <div nbSection padding="lg" divider="top">
       <span>Footer</span>
     </div>
   `,
 })
-class TopBorderSectionTest {}
+class TopDividerSectionTest {}
 
 @Component({
   imports: [NbSection],
   template: `
-    <div nbSection border="block" borderStyle="dashed" padding="xl">
+    <div nbSection divider="block" dividerStyle="dashed" padding="xl">
       <span>Block dashed</span>
     </div>
   `,
@@ -56,8 +56,8 @@ describe('NbSection', () => {
 
     expect(section.getAttribute('data-nb-section')).toBe('');
     expect(section.getAttribute('data-padding')).toBe('md');
-    expect(section.getAttribute('data-border')).toBe('none');
-    expect(section.getAttribute('data-border-style')).toBe('solid');
+    expect(section.getAttribute('data-divider')).toBe('none');
+    expect(section.getAttribute('data-divider-style')).toBe('solid');
     expect(section.getAttribute('data-layout')).toBe('default');
     expect(section.getAttribute('data-align')).toBe('stretch');
     expect(section.getAttribute('data-flush')).toBeNull();
@@ -65,39 +65,35 @@ describe('NbSection', () => {
     expect(section.className).toContain('min-w-0');
     expect(section.className).toContain('block');
     expect(section.className).toContain('p-[var(--nb-section-padding)]');
-    expect(section.className).toContain('[--nb-section-padding:1rem]');
+    expect(section.style.getPropertyValue('--nb-section-padding')).toBe('1rem');
     expect(section.className).not.toContain('border-t-');
     expect(section.className).not.toContain('items-stretch');
   });
 
-  it('renders a top border with the configured padding', async () => {
-    const fixture = await createFixture(TopBorderSectionTest);
+  it('renders a top divider with the configured padding', async () => {
+    const fixture = await createFixture(TopDividerSectionTest);
     const section = fixture.nativeElement.querySelector(
       '[nbSection]'
     ) as HTMLElement;
 
     expect(section.getAttribute('data-padding')).toBe('lg');
-    expect(section.getAttribute('data-border')).toBe('top');
-    expect(section.className).toContain('[--nb-section-padding:1.5rem]');
-    expect(section.className).toContain(
-      'border-t-(length:--nb-border-width)'
-    );
+    expect(section.getAttribute('data-divider')).toBe('top');
+    expect(section.style.getPropertyValue('--nb-section-padding')).toBe('1.5rem');
+    expect(section.className).toContain('border-t-(length:--nb-border-width)');
     expect(section.className).toContain('border-(--nb-border)');
     expect(section.className).toContain('border-solid');
   });
 
-  it('maps block border with dashed style', async () => {
+  it('maps block divider with dashed style', async () => {
     const fixture = await createFixture(DashedBlockSectionTest);
     const section = fixture.nativeElement.querySelector(
       '[nbSection]'
     ) as HTMLElement;
 
-    expect(section.getAttribute('data-border')).toBe('block');
-    expect(section.getAttribute('data-border-style')).toBe('dashed');
-    expect(section.className).toContain('[--nb-section-padding:2rem]');
-    expect(section.className).toContain(
-      'border-y-(length:--nb-border-width)'
-    );
+    expect(section.getAttribute('data-divider')).toBe('block');
+    expect(section.getAttribute('data-divider-style')).toBe('dashed');
+    expect(section.style.getPropertyValue('--nb-section-padding')).toBe('2rem');
+    expect(section.className).toContain('border-y-(length:--nb-border-width)');
     expect(section.className).toContain('border-dashed');
     expect(section.className).not.toContain('border-solid');
   });

--- a/libs/ui/src/lib/section/nb-section.ts
+++ b/libs/ui/src/lib/section/nb-section.ts
@@ -1,20 +1,23 @@
 import { Directive, booleanAttribute, computed, input } from '@angular/core';
 
 import { nbClass } from '../core/class';
+import {
+  NbPaddingCapability,
+  NB_STYLE_DEFAULTS,
+  NB_STYLE_NAMESPACE,
+  type NbStyleDefaults,
+} from '../core/capabilities';
+import type { NbDivider } from '../tokens/divider';
+import type { NbPadding } from '../tokens/padding';
 
-export type NbSectionPadding = 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+export type NbSectionPadding = NbPadding;
 
-export type NbSectionBorder =
-  | 'none'
-  | 'top'
-  | 'right'
-  | 'bottom'
-  | 'left'
-  | 'block'
-  | 'inline'
-  | 'all';
+// `divider` is line placement between regions — distinct from `border`
+// (outline strength) elsewhere in the library. Renamed from the former
+// `border` input so `border` means strength library-wide.
+export type NbSectionDivider = NbDivider;
 
-export type NbSectionBorderStyle = 'solid' | 'dashed' | 'dotted';
+export type NbSectionDividerStyle = 'solid' | 'dashed' | 'dotted';
 
 export type NbSectionLayout = 'default' | 'center' | 'between';
 
@@ -23,49 +26,43 @@ export type NbSectionAlign = 'stretch' | 'start' | 'center' | 'end';
 @Directive({
   selector: '[nbSection]',
   exportAs: 'nbSection',
+  providers: [
+    { provide: NB_STYLE_NAMESPACE, useValue: 'section' },
+    {
+      provide: NB_STYLE_DEFAULTS,
+      useValue: { padding: 'md' } satisfies NbStyleDefaults,
+    },
+  ],
+  hostDirectives: [{ directive: NbPaddingCapability, inputs: ['padding'] }],
   host: {
     '[class]': 'classes()',
     '[attr.data-nb-section]': '""',
-    '[attr.data-padding]': 'padding()',
-    '[attr.data-border]': 'border()',
-    '[attr.data-border-style]': 'borderStyle()',
+    '[attr.data-divider]': 'divider()',
+    '[attr.data-divider-style]': 'dividerStyle()',
     '[attr.data-layout]': 'layout()',
     '[attr.data-align]': 'align()',
     '[attr.data-flush]': 'flush() ? "" : null',
   },
 })
 export class NbSection {
-  readonly padding = input<NbSectionPadding>('md');
-  readonly border = input<NbSectionBorder>('none');
-  readonly borderStyle = input<NbSectionBorderStyle>('solid');
+  readonly divider = input<NbSectionDivider>('none');
+  readonly dividerStyle = input<NbSectionDividerStyle>('solid');
   readonly layout = input<NbSectionLayout>('default');
   readonly align = input<NbSectionAlign>('stretch');
-  readonly flush = input<boolean, unknown>(false, { transform: booleanAttribute });
+  readonly flush = input<boolean, unknown>(false, {
+    transform: booleanAttribute,
+  });
 
   protected readonly classes = computed(() =>
     nbClass(
       'box-border min-w-0',
       'p-[var(--nb-section-padding)]',
-      this.paddingClass(),
       this.layoutClass(),
       this.alignClass(),
-      this.borderClass(),
+      this.dividerClass(),
       this.flush() && 'mx-[calc(var(--nb-section-padding)*-1)]'
     )
   );
-
-  private paddingClass(): string {
-    const map: Record<NbSectionPadding, string> = {
-      none: '[--nb-section-padding:0px]',
-      xs: '[--nb-section-padding:0.5rem]',
-      sm: '[--nb-section-padding:0.75rem]',
-      md: '[--nb-section-padding:1rem]',
-      lg: '[--nb-section-padding:1.5rem]',
-      xl: '[--nb-section-padding:2rem]',
-    };
-
-    return map[this.padding()];
-  }
 
   private layoutClass(): string {
     const map: Record<NbSectionLayout, string> = {
@@ -92,16 +89,16 @@ export class NbSection {
     return map[this.align()];
   }
 
-  private borderClass(): string {
-    const side = this.border();
+  private dividerClass(): string {
+    const side = this.divider();
 
     if (side === 'none') {
       return '';
     }
 
-    const style = this.borderStyleClass();
+    const style = this.dividerStyleClass();
 
-    const widthMap: Record<Exclude<NbSectionBorder, 'none'>, string> = {
+    const widthMap: Record<Exclude<NbSectionDivider, 'none'>, string> = {
       top: 'border-t-(length:--nb-border-width)',
       right: 'border-r-(length:--nb-border-width)',
       bottom: 'border-b-(length:--nb-border-width)',
@@ -114,13 +111,13 @@ export class NbSection {
     return nbClass(widthMap[side], 'border-(--nb-border)', style);
   }
 
-  private borderStyleClass(): string {
-    const map: Record<NbSectionBorderStyle, string> = {
+  private dividerStyleClass(): string {
+    const map: Record<NbSectionDividerStyle, string> = {
       solid: 'border-solid',
       dashed: 'border-dashed',
       dotted: 'border-dotted',
     };
 
-    return map[this.borderStyle()];
+    return map[this.dividerStyle()];
   }
 }

--- a/libs/ui/src/lib/split/nb-split.spec.ts
+++ b/libs/ui/src/lib/split/nb-split.spec.ts
@@ -83,8 +83,8 @@ describe('NbSplit', () => {
     expect(split.className).toContain('min-w-0');
     expect(split.className).toContain('gap-[var(--nb-split-gap)]');
     expect(split.className).toContain('p-[var(--nb-split-padding)]');
-    expect(split.className).toContain('[--nb-split-gap:1rem]');
-    expect(split.className).toContain('[--nb-split-padding:0px]');
+    expect(split.style.getPropertyValue('--nb-split-gap')).toBe('1rem');
+    expect(split.style.getPropertyValue('--nb-split-padding')).toBe('0px');
     expect(split.className).toContain('items-stretch');
     expect(split.className).toContain(
       '[--nb-split-columns:minmax(0,1fr)_minmax(0,1fr)]'
@@ -108,8 +108,8 @@ describe('NbSplit', () => {
     expect(split.getAttribute('data-collapse')).toBe('lg');
     expect(split.getAttribute('data-align')).toBe('end');
     expect(split.getAttribute('data-divider')).toBe('none');
-    expect(split.className).toContain('[--nb-split-gap:2rem]');
-    expect(split.className).toContain('[--nb-split-padding:2rem]');
+    expect(split.style.getPropertyValue('--nb-split-gap')).toBe('2rem');
+    expect(split.style.getPropertyValue('--nb-split-padding')).toBe('2rem');
     expect(split.className).toContain('items-end');
     expect(split.className).toContain(
       '[--nb-split-columns:minmax(0,3fr)_minmax(0,1fr)]'

--- a/libs/ui/src/lib/split/nb-split.ts
+++ b/libs/ui/src/lib/split/nb-split.ts
@@ -1,6 +1,15 @@
 import { Directive, computed, input } from '@angular/core';
 
 import { nbClass } from '../core/class';
+import {
+  NbGapCapability,
+  NbPaddingCapability,
+  NB_STYLE_DEFAULTS,
+  NB_STYLE_NAMESPACE,
+  type NbStyleDefaults,
+} from '../core/capabilities';
+import type { NbPadding } from '../tokens/padding';
+import type { NbSpacing } from '../tokens/spacing';
 
 export type NbSplitRatio =
   | '1:1'
@@ -11,9 +20,9 @@ export type NbSplitRatio =
   | 'fill:auto'
   | 'auto:fill';
 
-export type NbSplitGap = 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+export type NbSplitGap = NbSpacing;
 
-export type NbSplitPadding = 'none' | 'sm' | 'md' | 'lg' | 'xl';
+export type NbSplitPadding = NbPadding;
 
 export type NbSplitCollapse = 'none' | 'sm' | 'md' | 'lg';
 
@@ -23,12 +32,21 @@ export type NbSplitDivider = 'none' | 'solid' | 'dashed' | 'thick';
 
 @Directive({
   selector: '[nbSplit]',
+  providers: [
+    { provide: NB_STYLE_NAMESPACE, useValue: 'split' },
+    {
+      provide: NB_STYLE_DEFAULTS,
+      useValue: { gap: 'lg', padding: 'none' } satisfies NbStyleDefaults,
+    },
+  ],
+  hostDirectives: [
+    { directive: NbGapCapability, inputs: ['gap'] },
+    { directive: NbPaddingCapability, inputs: ['padding'] },
+  ],
   host: {
     '[class]': 'classes()',
     '[attr.data-nb-split]': '""',
     '[attr.data-ratio]': 'ratio()',
-    '[attr.data-gap]': 'gap()',
-    '[attr.data-padding]': 'padding()',
     '[attr.data-collapse]': 'collapse()',
     '[attr.data-align]': 'align()',
     '[attr.data-divider]': 'divider()',
@@ -36,8 +54,6 @@ export type NbSplitDivider = 'none' | 'solid' | 'dashed' | 'thick';
 })
 export class NbSplit {
   readonly ratio = input<NbSplitRatio>('1:1');
-  readonly gap = input<NbSplitGap>('lg');
-  readonly padding = input<NbSplitPadding>('none');
   readonly collapse = input<NbSplitCollapse>('md');
   readonly align = input<NbSplitAlign>('stretch');
   readonly divider = input<NbSplitDivider>('none');
@@ -47,40 +63,12 @@ export class NbSplit {
       'grid min-w-0',
       'gap-[var(--nb-split-gap)]',
       'p-[var(--nb-split-padding)]',
-      this.gapClass(),
-      this.paddingClass(),
       this.alignClass(),
       this.ratioClass(),
       this.collapseClass(),
       this.dividerClass()
     )
   );
-
-  private gapClass(): string {
-    const map: Record<NbSplitGap, string> = {
-      none: '[--nb-split-gap:0px]',
-      xs: '[--nb-split-gap:0.25rem]',
-      sm: '[--nb-split-gap:0.5rem]',
-      md: '[--nb-split-gap:0.75rem]',
-      lg: '[--nb-split-gap:1rem]',
-      xl: '[--nb-split-gap:1.5rem]',
-      '2xl': '[--nb-split-gap:2rem]',
-    };
-
-    return map[this.gap()];
-  }
-
-  private paddingClass(): string {
-    const map: Record<NbSplitPadding, string> = {
-      none: '[--nb-split-padding:0px]',
-      sm: '[--nb-split-padding:0.75rem]',
-      md: '[--nb-split-padding:1rem]',
-      lg: '[--nb-split-padding:1.5rem]',
-      xl: '[--nb-split-padding:2rem]',
-    };
-
-    return map[this.padding()];
-  }
 
   private alignClass(): string {
     const map: Record<NbSplitAlign, string> = {

--- a/libs/ui/src/lib/stack/nb-stack.spec.ts
+++ b/libs/ui/src/lib/stack/nb-stack.spec.ts
@@ -59,7 +59,7 @@ describe('NbStack', () => {
     expect(stack.className).toContain('min-w-0');
     expect(stack.className).toContain('flex-col');
     expect(stack.className).toContain('gap-[var(--nb-stack-gap)]');
-    expect(stack.className).toContain('[--nb-stack-gap:0.75rem]');
+    expect(stack.style.getPropertyValue('--nb-stack-gap')).toBe('0.75rem');
     expect(stack.className).toContain('items-stretch');
     expect(stack.className).toContain('justify-start');
     expect(stack.className).not.toContain('[&>*+*]:border-t');
@@ -75,7 +75,7 @@ describe('NbStack', () => {
     expect(stack.getAttribute('data-align')).toBe('start');
     expect(stack.getAttribute('data-justify')).toBe('center');
     expect(stack.getAttribute('data-divider')).toBe('dashed');
-    expect(stack.className).toContain('[--nb-stack-gap:1.5rem]');
+    expect(stack.style.getPropertyValue('--nb-stack-gap')).toBe('1.5rem');
     expect(stack.className).toContain('items-start');
     expect(stack.className).toContain('justify-center');
     expect(stack.className).toContain(

--- a/libs/ui/src/lib/stack/nb-stack.ts
+++ b/libs/ui/src/lib/stack/nb-stack.ts
@@ -1,8 +1,15 @@
 import { Directive, computed, input } from '@angular/core';
 
 import { nbClass } from '../core/class';
+import {
+  NbGapCapability,
+  NB_STYLE_DEFAULTS,
+  NB_STYLE_NAMESPACE,
+  type NbStyleDefaults,
+} from '../core/capabilities';
+import type { NbSpacing } from '../tokens/spacing';
 
-export type NbStackGap = 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+export type NbStackGap = NbSpacing;
 
 export type NbStackAlign = 'stretch' | 'start' | 'center' | 'end';
 
@@ -12,17 +19,23 @@ export type NbStackDivider = 'none' | 'solid' | 'dashed' | 'thick';
 
 @Directive({
   selector: '[nbStack]',
+  providers: [
+    { provide: NB_STYLE_NAMESPACE, useValue: 'stack' },
+    {
+      provide: NB_STYLE_DEFAULTS,
+      useValue: { gap: 'md' } satisfies NbStyleDefaults,
+    },
+  ],
+  hostDirectives: [{ directive: NbGapCapability, inputs: ['gap'] }],
   host: {
     '[class]': 'classes()',
     '[attr.data-nb-stack]': '""',
-    '[attr.data-gap]': 'gap()',
     '[attr.data-align]': 'align()',
     '[attr.data-justify]': 'justify()',
     '[attr.data-divider]': 'divider()',
   },
 })
 export class NbStack {
-  readonly gap = input<NbStackGap>('md');
   readonly align = input<NbStackAlign>('stretch');
   readonly justify = input<NbStackJustify>('start');
   readonly divider = input<NbStackDivider>('none');
@@ -31,26 +44,11 @@ export class NbStack {
     nbClass(
       'flex min-w-0 flex-col',
       'gap-[var(--nb-stack-gap)]',
-      this.gapClass(),
       this.alignClass(),
       this.justifyClass(),
       this.dividerClass()
     )
   );
-
-  private gapClass(): string {
-    const map: Record<NbStackGap, string> = {
-      none: '[--nb-stack-gap:0px]',
-      xs: '[--nb-stack-gap:0.25rem]',
-      sm: '[--nb-stack-gap:0.5rem]',
-      md: '[--nb-stack-gap:0.75rem]',
-      lg: '[--nb-stack-gap:1rem]',
-      xl: '[--nb-stack-gap:1.5rem]',
-      '2xl': '[--nb-stack-gap:2rem]',
-    };
-
-    return map[this.gap()];
-  }
 
   private alignClass(): string {
     const map: Record<NbStackAlign, string> = {

--- a/libs/ui/src/lib/surface/nb-surface.spec.ts
+++ b/libs/ui/src/lib/surface/nb-surface.spec.ts
@@ -39,23 +39,8 @@ class ToneSurfaceTest {
 
 @Component({
   imports: [NbSurface],
-  template: `<div nbSurface style="--nb-surface-bg: #fff1dc">
-    Custom background
-  </div>`,
-})
-class CustomBgSurfaceTest {}
-
-@Component({
-  imports: [NbSurface],
   template: `
-    <section
-      nbSurface
-      border="strong"
-      layout="stack"
-      radius="base"
-      shadow="lifted"
-      clip
-    >
+    <section nbSurface border="strong" layout="stack" radius="lg" shadow="hard" clip>
       Flight card
     </section>
   `,
@@ -81,12 +66,13 @@ class FlightCardSurfaceTest {}
 class HeaderBandSurfaceTest {}
 
 describe('NbSurface', () => {
-  it('applies default brutalist surface classes and metadata', async () => {
+  it('applies default brutalist surface classes, metadata, and component variables', async () => {
     const fixture = await createFixture(DefaultSurfaceTest);
     const surface = fixture.nativeElement.querySelector(
       '[nbSurface]'
     ) as HTMLElement;
 
+    // Resolved tokens are reflected as data-* by the composed capabilities.
     expect(surface.getAttribute('data-nb-surface')).toBe('');
     expect(surface.getAttribute('data-tone')).toBe('default');
     expect(surface.getAttribute('data-radius')).toBe('md');
@@ -94,29 +80,30 @@ describe('NbSurface', () => {
     expect(surface.getAttribute('data-shadow')).toBe('default');
     expect(surface.getAttribute('data-padding')).toBe('none');
     expect(surface.getAttribute('data-edge')).toBe('none');
+
+    // Consumption-only classes — the variables come from the capabilities.
     expect(surface.className).toContain('relative');
-    expect(surface.className).toContain(
-      'bg-[var(--nb-surface-bg,var(--nb-surface-bg-base))]'
-    );
-    expect(surface.className).toContain(
-      'text-[var(--nb-surface-fg,var(--nb-surface-fg-base))]'
-    );
-    expect(surface.className).toContain(
-      'border-(length:--nb-surface-border-width)'
-    );
-    expect(surface.className).toContain('border-(--nb-surface-border)');
+    expect(surface.className).toContain('bg-(--nb-surface-bg)');
+    expect(surface.className).toContain('text-(--nb-surface-fg)');
+    expect(surface.className).toContain('border-(length:--nb-surface-border-width)');
+    expect(surface.className).toContain('border-(--nb-surface-border-color)');
     expect(surface.className).toContain('rounded-(--nb-surface-radius)');
     expect(surface.className).toContain('shadow-[var(--nb-surface-shadow)]');
-    expect(surface.style.getPropertyValue('--nb-surface-bg-base')).toBe(
-      'var(--nb-surface)'
-    );
-    expect(surface.className).toContain(
-      '[--nb-surface-radius:var(--nb-radius)]'
-    );
-    expect(surface.className).toContain(
-      '[--nb-surface-border-width:var(--nb-border-width)]'
-    );
     expect(surface.className).not.toContain('overflow-hidden');
+
+    // Component-specific CSS variables written by the capabilities.
+    const style = surface.style;
+    expect(style.getPropertyValue('--nb-surface-bg')).toBe('var(--nb-surface)');
+    expect(style.getPropertyValue('--nb-surface-fg')).toBe(
+      'var(--nb-surface-foreground)'
+    );
+    expect(style.getPropertyValue('--nb-surface-border-color')).toBe(
+      'var(--nb-border)'
+    );
+    expect(style.getPropertyValue('--nb-surface-radius')).toBe('var(--nb-radius)');
+    expect(style.getPropertyValue('--nb-surface-border-width')).toBe(
+      'var(--nb-border-width)'
+    );
   });
 
   it('maps tone, radius, border, shadow, and bare clip attributes', async () => {
@@ -131,13 +118,14 @@ describe('NbSurface', () => {
     expect(surface.getAttribute('data-shadow')).toBe('heavy');
     expect(surface.getAttribute('data-size')).toBe('lg');
     expect(surface.getAttribute('data-layout')).toBe('center');
-    expect(surface.style.getPropertyValue('--nb-surface-bg-base')).toBe(
+
+    expect(surface.style.getPropertyValue('--nb-surface-bg')).toBe(
       'var(--nb-cream)'
     );
-    expect(surface.className).toContain('[--nb-surface-radius:1.5rem]');
-    expect(surface.className).toContain('[--nb-surface-border-width:4px]');
-    expect(surface.className).toContain(
-      '[--nb-surface-shadow:10px_10px_0_0_var(--nb-shadow)]'
+    expect(surface.style.getPropertyValue('--nb-surface-radius')).toBe('1.5rem');
+    expect(surface.style.getPropertyValue('--nb-surface-border-width')).toBe('4px');
+    expect(surface.style.getPropertyValue('--nb-surface-shadow')).toBe(
+      '10px 10px 0 0 var(--nb-shadow)'
     );
     expect(surface.className).toContain('size-11');
     expect(surface.className).toContain('shrink-0');
@@ -164,39 +152,22 @@ describe('NbSurface', () => {
       ) as HTMLElement;
 
       expect(surface.getAttribute('data-tone')).toBe(tone);
-      expect(surface.style.getPropertyValue('--nb-surface-bg-base')).toBe(color);
+      expect(surface.style.getPropertyValue('--nb-surface-bg')).toBe(color);
     }
   );
 
-  it('lets a consumer override --nb-surface-bg without it being clobbered by the tone', async () => {
-    const fixture = await createFixture(CustomBgSurfaceTest);
+  it('writes the namespaced --nb-surface-bg from the tone capability', async () => {
+    const fixture = await createFixture(ToneSurfaceTest, (instance) => {
+      instance.tone = 'mint';
+    });
     const surface = fixture.nativeElement.querySelector(
       '[nbSurface]'
     ) as HTMLElement;
 
-    // Tone still drives the base var...
-    expect(surface.style.getPropertyValue('--nb-surface-bg-base')).toBe(
-      'var(--nb-surface)'
+    // Tone owns the surface-namespaced background variable directly.
+    expect(surface.style.getPropertyValue('--nb-surface-bg')).toBe(
+      'var(--nb-mint)'
     );
-    // ...but the consumer's inline override survives because the directive
-    // no longer writes --nb-surface-bg itself.
-    expect(surface.style.getPropertyValue('--nb-surface-bg')).toBe('#fff1dc');
-  });
-
-  it('supports a base radius between sm and lg for compact icon surfaces', async () => {
-    @Component({
-      imports: [NbSurface],
-      template: `<span nbSurface radius="base">Icon</span>`,
-    })
-    class BaseRadiusSurfaceTest {}
-
-    const fixture = await createFixture(BaseRadiusSurfaceTest);
-    const surface = fixture.nativeElement.querySelector(
-      '[nbSurface]'
-    ) as HTMLElement;
-
-    expect(surface.getAttribute('data-radius')).toBe('base');
-    expect(surface.className).toContain('[--nb-surface-radius:0.5rem]');
   });
 
   it('supports strong stacked surfaces for compact card shells', async () => {
@@ -207,12 +178,13 @@ describe('NbSurface', () => {
 
     expect(surface.getAttribute('data-border')).toBe('strong');
     expect(surface.getAttribute('data-layout')).toBe('stack');
-    expect(surface.getAttribute('data-radius')).toBe('base');
-    expect(surface.getAttribute('data-shadow')).toBe('lifted');
-    expect(surface.className).toContain('[--nb-surface-border-width:3px]');
-    expect(surface.className).toContain(
-      '[--nb-surface-shadow:7px_7px_0_0_var(--nb-shadow)]'
+    expect(surface.getAttribute('data-radius')).toBe('lg');
+    expect(surface.getAttribute('data-shadow')).toBe('hard');
+    expect(surface.style.getPropertyValue('--nb-surface-border-width')).toBe('3px');
+    expect(surface.style.getPropertyValue('--nb-surface-shadow')).toBe(
+      '6px 6px 0 0 var(--nb-shadow)'
     );
+    expect(surface.style.getPropertyValue('--nb-surface-radius')).toBe('1rem');
     expect(surface.className).toContain('flex');
     expect(surface.className).toContain('flex-col');
     expect(surface.className).toContain('overflow-hidden');
@@ -234,7 +206,8 @@ describe('NbSurface', () => {
     expect(surface.className).toContain('items-center');
     expect(surface.className).toContain('px-4');
     expect(surface.className).toContain('py-3');
-    expect(surface.className).toContain('[--nb-surface-border-width:0px]');
+    expect(surface.style.getPropertyValue('--nb-surface-border-width')).toBe('0px');
+    expect(surface.style.getPropertyValue('--nb-surface-shadow')).toBe('none');
     expect(surface.className).toContain('border-b-(length:--nb-surface-edge-width)');
     expect(surface.className).toContain('border-b-(--nb-surface-edge-color)');
   });

--- a/libs/ui/src/lib/surface/nb-surface.ts
+++ b/libs/ui/src/lib/surface/nb-surface.ts
@@ -1,150 +1,87 @@
 import { Directive, booleanAttribute, computed, input } from '@angular/core';
 
 import { nbClass } from '../core/class';
-import { nbToneTokens, type NbTone, type NbToneTokens } from '../tokens/tone';
+import {
+  NbBorderCapability,
+  NbRadiusCapability,
+  NbShadowCapability,
+  NbToneCapability,
+  NB_STYLE_DEFAULTS,
+  NB_STYLE_NAMESPACE,
+  type NbStyleDefaults,
+} from '../core/capabilities';
+import type { NbBorderStrength } from '../tokens/border';
+import type { NbRadius } from '../tokens/radius';
+import type { NbShadow } from '../tokens/shadow';
+import type { NbToneToken } from '../tokens/tone';
 
-export type NbSurfaceTone =
-  | NbTone
-  | 'background'
-  | 'surface';
+// Public type aliases — kept for API stability. They now point at the shared
+// token contracts so a token means the same thing across every primitive.
+export type NbSurfaceTone = NbToneToken;
+export type NbSurfaceRadius = NbRadius;
+export type NbSurfaceBorder = NbBorderStrength;
+export type NbSurfaceShadow = NbShadow;
 
-export type NbSurfaceRadius =
-  | 'none'
-  | 'sm'
-  | 'base'
-  | 'md'
-  | 'lg'
-  | 'xl'
-  | 'full';
-
-export type NbSurfaceBorder =
-  | 'none'
-  | 'thin'
-  | 'default'
-  | 'strong'
-  | 'thick';
-
-export type NbSurfaceShadow =
-  | 'none'
-  | 'sm'
-  | 'default'
-  | 'hard'
-  | 'lifted'
-  | 'heavy';
-
+// Surface-specific anatomy (not shared tokens).
 export type NbSurfaceSize = 'auto' | 'sm' | 'md' | 'lg' | 'xl';
-
 export type NbSurfaceLayout = 'block' | 'center' | 'row' | 'stack';
-
 export type NbSurfacePadding = 'none' | 'sm' | 'md' | 'lg';
-
 export type NbSurfaceEdge = 'none' | 'top' | 'bottom';
 
 @Directive({
   selector: '[nbSurface]',
+  providers: [
+    { provide: NB_STYLE_NAMESPACE, useValue: 'surface' },
+    {
+      provide: NB_STYLE_DEFAULTS,
+      useValue: {
+        tone: 'default',
+        radius: 'md',
+        shadow: 'default',
+        border: 'default',
+      } satisfies NbStyleDefaults,
+    },
+  ],
+  hostDirectives: [
+    { directive: NbToneCapability, inputs: ['tone'] },
+    { directive: NbRadiusCapability, inputs: ['radius'] },
+    { directive: NbShadowCapability, inputs: ['shadow'] },
+    { directive: NbBorderCapability, inputs: ['border'] },
+  ],
   host: {
     '[class]': 'classes()',
     '[attr.data-nb-surface]': '""',
-    '[attr.data-tone]': 'tone()',
-    '[attr.data-radius]': 'radius()',
-    '[attr.data-border]': 'border()',
-    '[attr.data-shadow]': 'shadow()',
     '[attr.data-size]': 'size()',
     '[attr.data-layout]': 'layout()',
     '[attr.data-padding]': 'padding()',
     '[attr.data-edge]': 'edge()',
-    '[style.--nb-surface-bg-base]': 'toneTokens().bg',
-    '[style.--nb-surface-fg-base]': 'toneTokens().fg',
   },
 })
 export class NbSurface {
-  readonly tone = input<NbSurfaceTone>('default');
-  readonly radius = input<NbSurfaceRadius>('md');
-  readonly border = input<NbSurfaceBorder>('default');
-  readonly shadow = input<NbSurfaceShadow>('default');
   readonly size = input<NbSurfaceSize>('auto');
   readonly layout = input<NbSurfaceLayout>('block');
   readonly padding = input<NbSurfacePadding>('none');
   readonly edge = input<NbSurfaceEdge>('none');
-  readonly clip = input<boolean, unknown>(false, { transform: booleanAttribute });
+  readonly clip = input<boolean, unknown>(false, {
+    transform: booleanAttribute,
+  });
 
+  // Tone, radius, shadow, and border-width are written as `--nb-surface-*`
+  // variables by the composed capabilities; here we only *consume* them.
   protected readonly classes = computed(() =>
     nbClass(
       'relative',
-      'bg-[var(--nb-surface-bg,var(--nb-surface-bg-base))] text-[var(--nb-surface-fg,var(--nb-surface-fg-base))]',
-      'border-(length:--nb-surface-border-width) border-(--nb-surface-border)',
+      'bg-(--nb-surface-bg) text-(--nb-surface-fg)',
+      'border-(length:--nb-surface-border-width) border-(--nb-surface-border-color)',
       'rounded-(--nb-surface-radius)',
       'shadow-[var(--nb-surface-shadow)]',
       this.clip() && 'overflow-hidden',
-      this.radiusClass(),
-      this.borderClass(),
-      this.shadowClass(),
       this.sizeClass(),
       this.layoutClass(),
       this.paddingClass(),
       this.edgeClass()
     )
   );
-
-  protected readonly toneTokens = computed<NbToneTokens>(() => {
-    const tone = this.tone();
-
-    if (tone === 'background') {
-      return {
-        bg: 'var(--nb-background)',
-        fg: 'var(--nb-foreground)',
-      };
-    }
-
-    if (tone === 'surface') {
-      return nbToneTokens('default');
-    }
-
-    return nbToneTokens(tone);
-  });
-
-  private radiusClass(): string {
-    const map: Record<NbSurfaceRadius, string> = {
-      none: '[--nb-surface-radius:0px]',
-      sm: '[--nb-surface-radius:0.375rem]',
-      base: '[--nb-surface-radius:0.5rem]',
-      md: '[--nb-surface-radius:var(--nb-radius)]',
-      lg: '[--nb-surface-radius:1rem]',
-      xl: '[--nb-surface-radius:1.5rem]',
-      full: '[--nb-surface-radius:9999px]',
-    };
-
-    return map[this.radius()];
-  }
-
-  private borderClass(): string {
-    const map: Record<NbSurfaceBorder, string> = {
-      none: '[--nb-surface-border-width:0px] [--nb-surface-border:transparent]',
-      thin: '[--nb-surface-border-width:1px] [--nb-surface-border:var(--nb-border)]',
-      default:
-        '[--nb-surface-border-width:var(--nb-border-width)] [--nb-surface-border:var(--nb-border)]',
-      strong:
-        '[--nb-surface-border-width:3px] [--nb-surface-border:var(--nb-border)]',
-      thick:
-        '[--nb-surface-border-width:4px] [--nb-surface-border:var(--nb-border)]',
-    };
-
-    return map[this.border()];
-  }
-
-  private shadowClass(): string {
-    const map: Record<NbSurfaceShadow, string> = {
-      none: '[--nb-surface-shadow:none]',
-      sm: '[--nb-surface-shadow:2px_2px_0_0_var(--nb-shadow)]',
-      default:
-        '[--nb-surface-shadow:var(--nb-shadow-offset-x)_var(--nb-shadow-offset-y)_0_0_var(--nb-shadow)]',
-      hard: '[--nb-surface-shadow:6px_6px_0_0_var(--nb-shadow)]',
-      lifted: '[--nb-surface-shadow:7px_7px_0_0_var(--nb-shadow)]',
-      heavy: '[--nb-surface-shadow:10px_10px_0_0_var(--nb-shadow)]',
-    };
-
-    return map[this.shadow()];
-  }
 
   private sizeClass(): string {
     const map: Record<NbSurfaceSize, string> = {

--- a/libs/ui/src/lib/tokens/border.ts
+++ b/libs/ui/src/lib/tokens/border.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared border-strength scale. Resolves to a border *width* only — border
+ * *color* is owned by the tone vocabulary (`nbToneVars().borderColor`) so the
+ * two never fight. `default` tracks the themeable `--nb-border-width`.
+ */
+export type NbBorderStrength = 'none' | 'thin' | 'default' | 'strong' | 'thick';
+
+const BORDER_WIDTH_VALUES: Record<NbBorderStrength, string> = {
+  none: '0px',
+  thin: '1px',
+  default: 'var(--nb-border-width)',
+  strong: '3px',
+  thick: '4px',
+};
+
+export function nbBorderWidthValue(border: NbBorderStrength): string {
+  return BORDER_WIDTH_VALUES[border];
+}

--- a/libs/ui/src/lib/tokens/divider.ts
+++ b/libs/ui/src/lib/tokens/divider.ts
@@ -1,0 +1,14 @@
+/**
+ * Divider line placement between layout regions. Distinct from `border`
+ * (outline strength): `divider` describes *which side(s)* carry a separating
+ * line, while `border` describes *how thick* an element's outline is.
+ */
+export type NbDivider =
+  | 'none'
+  | 'top'
+  | 'right'
+  | 'bottom'
+  | 'left'
+  | 'block'
+  | 'inline'
+  | 'all';

--- a/libs/ui/src/lib/tokens/padding.ts
+++ b/libs/ui/src/lib/tokens/padding.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared container-padding scale (uniform). Used by layout/container primitives
+ * that own symmetric padding (nbSection / nbCluster / nbSplit). Pill-style
+ * primitives (nbChip) and asymmetric surfaces keep their own padding because
+ * their spacing is anatomy, not a uniform container token.
+ */
+export type NbPadding = 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+const PADDING_VALUES: Record<NbPadding, string> = {
+  none: '0px',
+  xs: '0.5rem',
+  sm: '0.75rem',
+  md: '1rem',
+  lg: '1.5rem',
+  xl: '2rem',
+};
+
+export function nbPaddingValue(padding: NbPadding): string {
+  return PADDING_VALUES[padding];
+}

--- a/libs/ui/src/lib/tokens/radius.ts
+++ b/libs/ui/src/lib/tokens/radius.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared brutalist radius scale. One geometry per token across all primitives —
+ * the single source of truth that internal radius capabilities resolve against.
+ *
+ * `md` maps to the themeable `--nb-radius` (default `0rem`, i.e. sharp corners).
+ */
+export type NbRadius = 'none' | 'sm' | 'md' | 'lg' | 'xl' | 'full';
+
+const RADIUS_VALUES: Record<NbRadius, string> = {
+  none: '0px',
+  sm: '0.375rem',
+  md: 'var(--nb-radius)',
+  lg: '1rem',
+  xl: '1.5rem',
+  full: '9999px',
+};
+
+export function nbRadiusValue(radius: NbRadius): string {
+  return RADIUS_VALUES[radius];
+}

--- a/libs/ui/src/lib/tokens/shadow.ts
+++ b/libs/ui/src/lib/tokens/shadow.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared brutalist offset-shadow scale. Values are chunky, hard-edged offset
+ * shadows (no blur) tinted with `--nb-shadow`. `default` tracks the themeable
+ * `--nb-shadow-offset-x/y`.
+ */
+export type NbShadow = 'none' | 'sm' | 'default' | 'hard' | 'heavy';
+
+const SHADOW_VALUES: Record<NbShadow, string> = {
+  none: 'none',
+  sm: '2px 2px 0 0 var(--nb-shadow)',
+  default:
+    'var(--nb-shadow-offset-x) var(--nb-shadow-offset-y) 0 0 var(--nb-shadow)',
+  hard: '6px 6px 0 0 var(--nb-shadow)',
+  heavy: '10px 10px 0 0 var(--nb-shadow)',
+};
+
+export function nbShadowValue(shadow: NbShadow): string {
+  return SHADOW_VALUES[shadow];
+}

--- a/libs/ui/src/lib/tokens/spacing.ts
+++ b/libs/ui/src/lib/tokens/spacing.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared spacing scale used for layout `gap` across nbStack / nbCluster /
+ * nbSplit. One source of truth so a given gap token means the same distance
+ * everywhere.
+ */
+export type NbSpacing =
+  | 'none'
+  | 'xs'
+  | 'sm'
+  | 'md'
+  | 'lg'
+  | 'xl'
+  | '2xl';
+
+const SPACING_VALUES: Record<NbSpacing, string> = {
+  none: '0px',
+  xs: '0.25rem',
+  sm: '0.5rem',
+  md: '0.75rem',
+  lg: '1rem',
+  xl: '1.5rem',
+  '2xl': '2rem',
+};
+
+export function nbSpacingValue(spacing: NbSpacing): string {
+  return SPACING_VALUES[spacing];
+}

--- a/libs/ui/src/lib/tokens/tone.ts
+++ b/libs/ui/src/lib/tokens/tone.ts
@@ -86,3 +86,46 @@ export const NB_TONE_TOKENS: Record<NbTone, NbToneTokens> = {
 export function nbToneTokens(tone: NbTone): NbToneTokens {
   return NB_TONE_TOKENS[tone];
 }
+
+/**
+ * Neutral tone aliases accepted by the tone capability in addition to the core
+ * {@link NbTone} palette. These map onto existing theme surfaces rather than
+ * the playful/semantic palette:
+ * - `surface`    → the default surface tokens
+ * - `background` → the page background/foreground
+ * - `ink`        → solid black (`black` tone)
+ */
+export type NbToneToken = NbTone | 'surface' | 'background' | 'ink';
+
+/**
+ * Component-specific tone variables: background, foreground, and border color.
+ * Border color is always the brutalist ink (`--nb-border`) so the border
+ * *width* capability and the tone capability never fight over color.
+ */
+export interface NbToneVars {
+  bg: string;
+  fg: string;
+  borderColor: string;
+}
+
+export function nbToneVars(tone: NbToneToken): NbToneVars {
+  const borderColor = 'var(--nb-border)';
+
+  if (tone === 'surface') {
+    return { ...nbToneTokens('default'), borderColor };
+  }
+
+  if (tone === 'background') {
+    return {
+      bg: 'var(--nb-background)',
+      fg: 'var(--nb-foreground)',
+      borderColor,
+    };
+  }
+
+  if (tone === 'ink') {
+    return { ...nbToneTokens('black'), borderColor };
+  }
+
+  return { ...nbToneTokens(tone), borderColor };
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * `NbSection` component: renamed `border` attribute to `divider` and `borderStyle` to `dividerStyle`
  * `NbSurface` component: updated default `radius` and `shadow` values

* **Documentation**
  * Added guides on component styling capabilities and API consistency standards

* **Tests**
  * Updated test assertions to validate CSS custom properties instead of utility classes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->