### PR TITLE
feat(skills): add ng-brutalism agent skill and reference documentation

### DIFF
--- a/skills/ng-brutalism/SKILL.md
+++ b/skills/ng-brutalism/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: ng-brutalism
+description: Build loud, token-driven, Angular-first brutalist UIs using composition primitives. USE WHEN the user wants to use ng-brutalism UI components, compose layouts, or build brutalist web apps.
+metadata:
+  version: 1.0.0
+  author: Henrique Custódia
+---
+
+# `ng-brutalism`
+
+This skill provides instructions on how to use `ng-brutalism`, an Angular UI component library designed around neo-brutalist aesthetics and primitive-based composition.
+
+**IMPORTANT: Progressive Disclosure**
+This document outlines the core mental model and the available components. **You must not guess the API or HTML structure of a component.** When you decide to use a specific component or composition pattern, **ALWAYS use `view_file` to read its detailed documentation in the `references/` directory** located alongside this file before implementing it.
+
+---
+
+## 1. The Mental Model
+
+`ng-brutalism` replaces class soup (like Tailwind utility spam) with semantic, token-driven composition primitives. Every primitive does one job well.
+
+- **`nbSurface`**: The brutalist panel (the base container).
+- **`nbSection`**: Regions inside a panel (e.g., header, body, footer).
+- **`nbStack`**: Vertical content flow and spacing.
+- **`nbCluster`**: Horizontal or wrapping content flow.
+- **`nbSplit`**: Two-column or main/aside layouts.
+- **Actions**: `nbButton`, `nbIconButton`.
+- **Metadata**: `nbChip`, `nbBadge`.
+- **Typography**: `nbTitle`, `nbDisplay`, `nbText`.
+- **Status**: `nbStatusDot`, `nbCallout`.
+
+### Shared API Language
+
+Every primitive in `ng-brutalism` speaks the same token vocabulary. The following attributes are universally used across the library:
+- **`tone`**: Visual intent / color theme (e.g., `primary`, `secondary`, `cream`, `yellow`, `mint`, `pink`, `lavender`).
+- **`size`**: Component scale (`sm`, `md`, `lg`, `xl`).
+- **`radius`**: Corner shape (`none`, `sm`, `md`, `lg`, `xl`, `full`).
+- **`shadow`**: Brutalist offset depth (`none`, `sm`, `default`, `hard`, `heavy`).
+- **`border`**: Outline strength (`none`, `thin`, `default`, `strong`, `thick`).
+- **`padding`**: Internal space (`none`, `sm`, `md`, `lg`, `xl`).
+- **`gap`**: Child spacing in flex containers (`none`, `xs`, `sm`, `md`, `lg`, `xl`, `2xl`).
+- **`align`**: Cross-axis alignment (`start`, `center`, `end`, `stretch`).
+- **`justify`**: Main-axis alignment (`start`, `center`, `end`, `between`, `around`).
+- **`clip`**: Keep inner regions inside the outer radius (used on `nbSurface`).
+- **`divider`**: Border between regions (used on `nbSection` - `top`, `bottom`, etc.).
+
+---
+
+## 2. Component Reference Directory
+
+When implementing any of the following components, **read the corresponding reference file first** to understand its exact API, inputs, and template usage examples.
+
+### Getting Started
+- Installation & Setup: `references/installation.md`
+
+### Layout & Composition Primitives
+*Read these to understand how to build complex layouts.*
+- `nbSurface` & `nbSection`: `references/surface-and-section.md`
+- `nbStack` & `nbCluster`: `references/stack-and-cluster.md`
+- Split Layouts: `references/split-layouts.md`
+- Common Patterns: `references/common-patterns.md`
+- Composition Overview: `references/overview.md`
+
+### UI Components
+*Use `view_file` on the corresponding path before using the component.*
+
+**Containers & Layout**
+- `nbSurface`: `references/surface.md`
+- `nbSection`: `references/section.md`
+- `nbStack`: `references/stack.md`
+- `nbCluster`: `references/cluster.md`
+- `nbSplit`: `references/split.md`
+- `nbCard`: `references/card.md`
+- `nbImageCard`: `references/image-card.md`
+- `nbMediaFrame`: `references/media-frame.md`
+- `nbMediaItem`: `references/media-item.md`
+
+**Typography & Display**
+- `nbTitle`: `references/title.md`
+- `nbDisplay`: `references/display.md`
+- `nbText`: `references/text.md`
+- `nbMarquee`: `references/marquee.md`
+- `nbHalftone`: `references/halftone.md`
+- `nbSeparator`: `references/separator.md`
+- `nbIcon`: `references/icon.md`
+
+**Actions & Inputs**
+- `nbButton`: `references/button.md`
+- `nbIconButton`: `references/icon-button.md`
+- `nbInput`: `references/input.md`
+- `nbInputGroup`: `references/input-group.md`
+- `nbTextarea`: `references/textarea.md`
+- `nbCheckbox`: `references/checkbox.md`
+- `nbSelect`: `references/select.md`
+- `nbLabel`: `references/label.md`
+
+**Data Display & Feedback**
+- `nbChip`: `references/chip.md`
+- `nbBadge`: `references/badge.md`
+- `nbAvatar`: `references/avatar.md`
+- `nbAvatarGroup`: `references/avatar-group.md`
+- `nbCallout`: `references/callout.md`
+- `nbDialog`: `references/dialog.md`
+- `nbAccordion`: `references/accordion.md`
+- `nbProgress`: `references/progress.md`
+- `nbRating`: `references/rating.md`
+- `nbStat`: `references/stat.md`
+- `nbStatusDot`: `references/status-dot.md`
+- `nbSticker`: `references/sticker.md`
+
+---
+
+## 3. Best Practices for AI Agents
+
+1. **Do not use Tailwind utility classes for structure or theming.** If you need a container, use `nbSurface`. If you need spacing, use `nbStack` or `nbCluster`. The primitives exist so you don't have to write raw classes.
+2. **Embrace loud colors.** Use `tone="mint"`, `tone="pink"`, `tone="yellow"`, etc. instead of writing custom CSS or inline styles.
+3. **Always refer to the API tables.** The reference markdown files contain tables that show the exact TypeScript types for properties like `radius`, `shadow`, and `padding`. Do not guess these values.
+4. **Use Content Projection:** Many components rely heavily on content projection (e.g., passing `nbText` into `nbButton`, or placing `nbTitle` inside `nbSection`). Review the examples in the reference files to see how components compose together.

--- a/skills/ng-brutalism/SKILL.md
+++ b/skills/ng-brutalism/SKILL.md
@@ -31,8 +31,11 @@ This document outlines the core mental model and the available components. **You
 
 ### Shared API Language
 
-Every primitive in `ng-brutalism` speaks the same token vocabulary. The following attributes are universally used across the library:
-- **`tone`**: Visual intent / color theme (e.g., `primary`, `secondary`, `cream`, `yellow`, `mint`, `pink`, `lavender`).
+Most primitives in `ng-brutalism` share a core token vocabulary, while component-specific properties are documented in each component reference. Use `references/common-patterns.md` for a quick tour of real compositions before reading the detailed component files.
+
+Core shared attributes:
+
+- **`tone`**: Visual intent / color theme (e.g., `default`, `surface`, `background`, `ink`, `white`, `black`, `primary`, `secondary`, `accent`, `cream`, `yellow`, `mint`, `pink`, `lavender`, `blue`, `success`, `warning`, `danger`).
 - **`size`**: Component scale (`sm`, `md`, `lg`, `xl`).
 - **`radius`**: Corner shape (`none`, `sm`, `md`, `lg`, `xl`, `full`).
 - **`shadow`**: Brutalist offset depth (`none`, `sm`, `default`, `hard`, `heavy`).
@@ -44,6 +47,13 @@ Every primitive in `ng-brutalism` speaks the same token vocabulary. The followin
 - **`clip`**: Keep inner regions inside the outer radius (used on `nbSurface`).
 - **`divider`**: Border between regions (used on `nbSection` - `top`, `bottom`, etc.).
 
+Common component-specific attributes used in examples:
+
+- **`layout`**: Section or callout content arrangement, such as `between`, `inline`, or `center`.
+- **`collapse`**: Responsive collapse behavior for `nbSplit`.
+- **`weight`**, **`leading`**, **`tracking`**, **`transform`**: Typography controls on `nbText`.
+- **`underline`** and **`underlineGap`**: Decorative underline controls on `nbDisplay` and `nbText`.
+
 ---
 
 ## 2. Component Reference Directory
@@ -51,10 +61,13 @@ Every primitive in `ng-brutalism` speaks the same token vocabulary. The followin
 When implementing any of the following components, **read the corresponding reference file first** to understand its exact API, inputs, and template usage examples.
 
 ### Getting Started
+
 - Installation & Setup: `references/installation.md`
 
 ### Layout & Composition Primitives
-*Read these to understand how to build complex layouts.*
+
+_Read these to understand how to build complex layouts._
+
 - `nbSurface` & `nbSection`: `references/surface-and-section.md`
 - `nbStack` & `nbCluster`: `references/stack-and-cluster.md`
 - Split Layouts: `references/split-layouts.md`
@@ -62,9 +75,11 @@ When implementing any of the following components, **read the corresponding refe
 - Composition Overview: `references/overview.md`
 
 ### UI Components
-*Use `view_file` on the corresponding path before using the component.*
+
+_Use `view_file` on the corresponding path before using the component._
 
 **Containers & Layout**
+
 - `nbSurface`: `references/surface.md`
 - `nbSection`: `references/section.md`
 - `nbStack`: `references/stack.md`
@@ -76,6 +91,7 @@ When implementing any of the following components, **read the corresponding refe
 - `nbMediaItem`: `references/media-item.md`
 
 **Typography & Display**
+
 - `nbTitle`: `references/title.md`
 - `nbDisplay`: `references/display.md`
 - `nbText`: `references/text.md`
@@ -85,6 +101,7 @@ When implementing any of the following components, **read the corresponding refe
 - `nbIcon`: `references/icon.md`
 
 **Actions & Inputs**
+
 - `nbButton`: `references/button.md`
 - `nbIconButton`: `references/icon-button.md`
 - `nbInput`: `references/input.md`
@@ -95,6 +112,7 @@ When implementing any of the following components, **read the corresponding refe
 - `nbLabel`: `references/label.md`
 
 **Data Display & Feedback**
+
 - `nbChip`: `references/chip.md`
 - `nbBadge`: `references/badge.md`
 - `nbAvatar`: `references/avatar.md`

--- a/skills/ng-brutalism/references/accordion.md
+++ b/skills/ng-brutalism/references/accordion.md
@@ -1,0 +1,157 @@
+# Accordion
+
+The neo-brutalist Angular Accordion component. A vertically stacked set of interactive headings that reveal related content panels with native button semantics, ARIA state, and brutalist borders.
+
+## Import
+```typescript
+import {
+  NbAccordion,
+  NbAccordionContent,
+  NbAccordionItem,
+  NbAccordionTrigger,
+} from '@ng-brutalism/ui';
+```
+
+## API Reference
+
+### Accordion (`nb-accordion`)
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `type` | `'single' \| 'multiple'` | `'single'` | The expansion behavior of the accordion. |
+| `collapsible` | `boolean` | `false` | Whether all items can be collapsed. |
+| `value` | `string \| string[] \| null` | `null` | The value of the expanded item(s). |
+
+### Accordion Item (`nb-accordion-item`)
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `value` | `string` | *(generated)* | A unique value identifying the accordion item. |
+| `disabled` | `boolean` | `false` | Whether the accordion item is disabled. |
+
+### Selectors
+| Selector | Description |
+|---|---|
+| `nb-accordion-trigger` | Toggles its parent item open or closed. Has no inputs. |
+| `nb-accordion-content` | Collapsible body region for an item. Has no inputs. |
+
+## Usage Examples
+
+### Default
+```html
+<nb-accordion class="block w-full max-w-xl" collapsible>
+  <nb-accordion-item>
+    <nb-accordion-trigger>Lorem, ipsum dolor.</nb-accordion-trigger>
+    <nb-accordion-content>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    </nb-accordion-content>
+  </nb-accordion-item>
+
+  <nb-accordion-item>
+    <nb-accordion-trigger>Lorem ipsum dolor sit amet consectetur.</nb-accordion-trigger>
+    <nb-accordion-content>
+      Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </nb-accordion-content>
+  </nb-accordion-item>
+</nb-accordion>
+```
+
+### Multiple
+```html
+<nb-accordion
+  class="block w-full max-w-xl"
+  type="multiple"
+  [value]="['item-1']"
+>
+  <nb-accordion-item value="item-1">
+    <nb-accordion-trigger>Can multiple panels open?</nb-accordion-trigger>
+    <nb-accordion-content>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    </nb-accordion-content>
+  </nb-accordion-item>
+
+  <nb-accordion-item value="item-2">
+    <nb-accordion-trigger>Can panels start open?</nb-accordion-trigger>
+    <nb-accordion-content>
+      Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.
+    </nb-accordion-content>
+  </nb-accordion-item>
+</nb-accordion>
+```
+
+### Controlled
+```typescript
+import { signal } from '@angular/core';
+
+readonly controlledValue = signal<string | string[] | null>('overview');
+```
+
+```html
+<div class="flex w-full max-w-xl flex-col gap-4">
+  <div class="flex flex-wrap gap-3">
+    <button
+      nbButton
+      size="sm"
+      tone="background"
+      type="button"
+      style="--nb-button-bg: var(--nb-warning)"
+      (click)="controlledValue.set('overview')"
+    >
+      Overview
+    </button>
+    <button
+      nbButton
+      size="sm"
+      tone="background"
+      type="button"
+      style="--nb-button-bg: var(--nb-success)"
+      (click)="controlledValue.set('details')"
+    >
+      Details
+    </button>
+    <button
+      nbButton
+      size="sm"
+      tone="background"
+      type="button"
+      style="--nb-button-bg: var(--nb-primary)"
+      (click)="controlledValue.set(null)"
+    >
+      Collapse All
+    </button>
+  </div>
+
+  <nb-accordion [(value)]="controlledValue">
+    <nb-accordion-item value="overview">
+      <nb-accordion-trigger style="--nb-accordion-trigger-bg: #b8a4ff">Overview</nb-accordion-trigger>
+      <nb-accordion-content>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      </nb-accordion-content>
+    </nb-accordion-item>
+
+    <nb-accordion-item value="details">
+      <nb-accordion-trigger style="--nb-accordion-trigger-bg: #b8a4ff">Details</nb-accordion-trigger>
+      <nb-accordion-content>
+        Duis aute irure dolor in reprehenderit in voluptate velit.
+      </nb-accordion-content>
+    </nb-accordion-item>
+  </nb-accordion>
+</div>
+```
+
+### Disabled Item
+```html
+<nb-accordion collapsible class="block w-full max-w-xl" [value]="'enabled'">
+  <nb-accordion-item value="enabled">
+    <nb-accordion-trigger>Enabled item</nb-accordion-trigger>
+    <nb-accordion-content>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    </nb-accordion-content>
+  </nb-accordion-item>
+
+  <nb-accordion-item value="disabled" disabled>
+    <nb-accordion-trigger>Disabled item</nb-accordion-trigger>
+    <nb-accordion-content>
+      Excepteur sint occaecat cupidatat non proident.
+    </nb-accordion-content>
+  </nb-accordion-item>
+</nb-accordion>
+```

--- a/skills/ng-brutalism/references/accordion.md
+++ b/skills/ng-brutalism/references/accordion.md
@@ -3,81 +3,71 @@
 The neo-brutalist Angular Accordion component. A vertically stacked set of interactive headings that reveal related content panels with native button semantics, ARIA state, and brutalist borders.
 
 ## Import
+
 ```typescript
-import {
-  NbAccordion,
-  NbAccordionContent,
-  NbAccordionItem,
-  NbAccordionTrigger,
-} from '@ng-brutalism/ui';
+import { NbAccordion, NbAccordionContent, NbAccordionItem, NbAccordionTrigger } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
 
 ### Accordion (`nb-accordion`)
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `type` | `'single' \| 'multiple'` | `'single'` | The expansion behavior of the accordion. |
-| `collapsible` | `boolean` | `false` | Whether all items can be collapsed. |
-| `value` | `string \| string[] \| null` | `null` | The value of the expanded item(s). |
+
+| Attribute     | Type                         | Default    | Description                              |
+| ------------- | ---------------------------- | ---------- | ---------------------------------------- |
+| `type`        | `'single' \| 'multiple'`     | `'single'` | The expansion behavior of the accordion. |
+| `collapsible` | `boolean`                    | `false`    | Whether all items can be collapsed.      |
+| `value`       | `string \| string[] \| null` | `null`     | The value of the expanded item(s).       |
 
 ### Accordion Item (`nb-accordion-item`)
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `value` | `string` | *(generated)* | A unique value identifying the accordion item. |
-| `disabled` | `boolean` | `false` | Whether the accordion item is disabled. |
+
+| Attribute  | Type      | Default       | Description                                    |
+| ---------- | --------- | ------------- | ---------------------------------------------- |
+| `value`    | `string`  | _(generated)_ | A unique value identifying the accordion item. |
+| `disabled` | `boolean` | `false`       | Whether the accordion item is disabled.        |
 
 ### Selectors
-| Selector | Description |
-|---|---|
+
+| Selector               | Description                                            |
+| ---------------------- | ------------------------------------------------------ |
 | `nb-accordion-trigger` | Toggles its parent item open or closed. Has no inputs. |
-| `nb-accordion-content` | Collapsible body region for an item. Has no inputs. |
+| `nb-accordion-content` | Collapsible body region for an item. Has no inputs.    |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <nb-accordion class="block w-full max-w-xl" collapsible>
   <nb-accordion-item>
     <nb-accordion-trigger>Lorem, ipsum dolor.</nb-accordion-trigger>
-    <nb-accordion-content>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    </nb-accordion-content>
+    <nb-accordion-content> Lorem ipsum dolor sit amet, consectetur adipiscing elit. </nb-accordion-content>
   </nb-accordion-item>
 
   <nb-accordion-item>
     <nb-accordion-trigger>Lorem ipsum dolor sit amet consectetur.</nb-accordion-trigger>
-    <nb-accordion-content>
-      Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </nb-accordion-content>
+    <nb-accordion-content> Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. </nb-accordion-content>
   </nb-accordion-item>
 </nb-accordion>
 ```
 
 ### Multiple
+
 ```html
-<nb-accordion
-  class="block w-full max-w-xl"
-  type="multiple"
-  [value]="['item-1']"
->
+<nb-accordion class="block w-full max-w-xl" type="multiple" [value]="['item-1']">
   <nb-accordion-item value="item-1">
     <nb-accordion-trigger>Can multiple panels open?</nb-accordion-trigger>
-    <nb-accordion-content>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    </nb-accordion-content>
+    <nb-accordion-content> Lorem ipsum dolor sit amet, consectetur adipiscing elit. </nb-accordion-content>
   </nb-accordion-item>
 
   <nb-accordion-item value="item-2">
     <nb-accordion-trigger>Can panels start open?</nb-accordion-trigger>
-    <nb-accordion-content>
-      Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.
-    </nb-accordion-content>
+    <nb-accordion-content> Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris. </nb-accordion-content>
   </nb-accordion-item>
 </nb-accordion>
 ```
 
 ### Controlled
+
 ```typescript
 import { signal } from '@angular/core';
 
@@ -87,71 +77,37 @@ readonly controlledValue = signal<string | string[] | null>('overview');
 ```html
 <div class="flex w-full max-w-xl flex-col gap-4">
   <div class="flex flex-wrap gap-3">
-    <button
-      nbButton
-      size="sm"
-      tone="background"
-      type="button"
-      style="--nb-button-bg: var(--nb-warning)"
-      (click)="controlledValue.set('overview')"
-    >
-      Overview
-    </button>
-    <button
-      nbButton
-      size="sm"
-      tone="background"
-      type="button"
-      style="--nb-button-bg: var(--nb-success)"
-      (click)="controlledValue.set('details')"
-    >
-      Details
-    </button>
-    <button
-      nbButton
-      size="sm"
-      tone="background"
-      type="button"
-      style="--nb-button-bg: var(--nb-primary)"
-      (click)="controlledValue.set(null)"
-    >
-      Collapse All
-    </button>
+    <button nbButton size="sm" tone="background" type="button" style="--nb-button-bg: var(--nb-warning)" (click)="controlledValue.set('overview')">Overview</button>
+    <button nbButton size="sm" tone="background" type="button" style="--nb-button-bg: var(--nb-success)" (click)="controlledValue.set('details')">Details</button>
+    <button nbButton size="sm" tone="background" type="button" style="--nb-button-bg: var(--nb-primary)" (click)="controlledValue.set(null)">Collapse All</button>
   </div>
 
   <nb-accordion [(value)]="controlledValue">
     <nb-accordion-item value="overview">
       <nb-accordion-trigger style="--nb-accordion-trigger-bg: #b8a4ff">Overview</nb-accordion-trigger>
-      <nb-accordion-content>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-      </nb-accordion-content>
+      <nb-accordion-content> Lorem ipsum dolor sit amet, consectetur adipiscing elit. </nb-accordion-content>
     </nb-accordion-item>
 
     <nb-accordion-item value="details">
       <nb-accordion-trigger style="--nb-accordion-trigger-bg: #b8a4ff">Details</nb-accordion-trigger>
-      <nb-accordion-content>
-        Duis aute irure dolor in reprehenderit in voluptate velit.
-      </nb-accordion-content>
+      <nb-accordion-content> Duis aute irure dolor in reprehenderit in voluptate velit. </nb-accordion-content>
     </nb-accordion-item>
   </nb-accordion>
 </div>
 ```
 
 ### Disabled Item
+
 ```html
 <nb-accordion collapsible class="block w-full max-w-xl" [value]="'enabled'">
   <nb-accordion-item value="enabled">
     <nb-accordion-trigger>Enabled item</nb-accordion-trigger>
-    <nb-accordion-content>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    </nb-accordion-content>
+    <nb-accordion-content> Lorem ipsum dolor sit amet, consectetur adipiscing elit. </nb-accordion-content>
   </nb-accordion-item>
 
   <nb-accordion-item value="disabled" disabled>
     <nb-accordion-trigger>Disabled item</nb-accordion-trigger>
-    <nb-accordion-content>
-      Excepteur sint occaecat cupidatat non proident.
-    </nb-accordion-content>
+    <nb-accordion-content> Excepteur sint occaecat cupidatat non proident. </nb-accordion-content>
   </nb-accordion-item>
 </nb-accordion>
 ```

--- a/skills/ng-brutalism/references/avatar-group.md
+++ b/skills/ng-brutalism/references/avatar-group.md
@@ -1,0 +1,34 @@
+# AvatarGroup
+
+A component that stacks `NbAvatar` elements with negative overlap and appends an overflow badge when the count exceeds what's shown. Common in charity, event, and social card designs.
+
+## Import
+```typescript
+import { NbAvatar, NbAvatarGroup } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `overflow` | `number` | `0` | Number of hidden members. Renders a `+N` badge when > 0. |
+
+## Usage Examples
+
+### Default
+```html
+<nb-avatar-group [overflow]="142">
+  <nb-avatar alt="Alice">A</nb-avatar>
+  <nb-avatar alt="Bob">B</nb-avatar>
+  <nb-avatar alt="Carol">C</nb-avatar>
+</nb-avatar-group>
+```
+
+### Without Overflow
+```html
+<nb-avatar-group>
+  <nb-avatar alt="Alice">A</nb-avatar>
+  <nb-avatar alt="Bob">B</nb-avatar>
+  <nb-avatar alt="Carol">C</nb-avatar>
+  <nb-avatar alt="Dave">D</nb-avatar>
+</nb-avatar-group>
+```

--- a/skills/ng-brutalism/references/avatar-group.md
+++ b/skills/ng-brutalism/references/avatar-group.md
@@ -3,18 +3,21 @@
 A component that stacks `NbAvatar` elements with negative overlap and appends an overflow badge when the count exceeds what's shown. Common in charity, event, and social card designs.
 
 ## Import
+
 ```typescript
 import { NbAvatar, NbAvatarGroup } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `overflow` | `number` | `0` | Number of hidden members. Renders a `+N` badge when > 0. |
+
+| Attribute  | Type     | Default | Description                                              |
+| ---------- | -------- | ------- | -------------------------------------------------------- |
+| `overflow` | `number` | `0`     | Number of hidden members. Renders a `+N` badge when > 0. |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <nb-avatar-group [overflow]="142">
   <nb-avatar alt="Alice">A</nb-avatar>
@@ -24,6 +27,7 @@ import { NbAvatar, NbAvatarGroup } from '@ng-brutalism/ui';
 ```
 
 ### Without Overflow
+
 ```html
 <nb-avatar-group>
   <nb-avatar alt="Alice">A</nb-avatar>

--- a/skills/ng-brutalism/references/avatar.md
+++ b/skills/ng-brutalism/references/avatar.md
@@ -3,24 +3,28 @@
 The neo-brutalist Angular Avatar component. A circular image frame with a thick border and offset shadow. Falls back to projected initials when no image source is provided.
 
 ## Import
+
 ```typescript
 import { NbAvatar } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `src` | `string \| undefined` | `undefined` | The URL of the image source. |
-| `alt` | `string` | `''` | The alternative text for the image. |
+
+| Attribute | Type                  | Default     | Description                         |
+| --------- | --------------------- | ----------- | ----------------------------------- |
+| `src`     | `string \| undefined` | `undefined` | The URL of the image source.        |
+| `alt`     | `string`              | `''`        | The alternative text for the image. |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <nb-avatar class="h-20 w-20" src="https://github.com/khangtrannn.png" alt="khangtrannn" />
 ```
 
 ### Fallback (Initials)
+
 ```html
 <nb-avatar alt="John Doe">JD</nb-avatar>
 ```

--- a/skills/ng-brutalism/references/avatar.md
+++ b/skills/ng-brutalism/references/avatar.md
@@ -1,0 +1,26 @@
+# Avatar
+
+The neo-brutalist Angular Avatar component. A circular image frame with a thick border and offset shadow. Falls back to projected initials when no image source is provided.
+
+## Import
+```typescript
+import { NbAvatar } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `src` | `string \| undefined` | `undefined` | The URL of the image source. |
+| `alt` | `string` | `''` | The alternative text for the image. |
+
+## Usage Examples
+
+### Default
+```html
+<nb-avatar class="h-20 w-20" src="https://github.com/khangtrannn.png" alt="khangtrannn" />
+```
+
+### Fallback (Initials)
+```html
+<nb-avatar alt="John Doe">JD</nb-avatar>
+```

--- a/skills/ng-brutalism/references/badge.md
+++ b/skills/ng-brutalism/references/badge.md
@@ -3,23 +3,27 @@
 The neo-brutalist Angular Badge component. A small status indicator with shared tone, radius, shadow, and border styling.
 
 ## Import
+
 ```typescript
 import { NbBadge } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `tone` | `NbToneToken` | `'white'` | Visual tone variation for the badge. |
+
+| Attribute | Type          | Default   | Description                          |
+| --------- | ------------- | --------- | ------------------------------------ |
+| `tone`    | `NbToneToken` | `'white'` | Visual tone variation for the badge. |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <span nbBadge>Default</span>
 ```
 
 ### Tones
+
 ```html
 <div class="flex flex-wrap items-center gap-3">
   <span nbBadge>Default</span>

--- a/skills/ng-brutalism/references/badge.md
+++ b/skills/ng-brutalism/references/badge.md
@@ -1,0 +1,31 @@
+# Badge
+
+The neo-brutalist Angular Badge component. A small status indicator with shared tone, radius, shadow, and border styling.
+
+## Import
+```typescript
+import { NbBadge } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `tone` | `NbToneToken` | `'white'` | Visual tone variation for the badge. |
+
+## Usage Examples
+
+### Default
+```html
+<span nbBadge>Default</span>
+```
+
+### Tones
+```html
+<div class="flex flex-wrap items-center gap-3">
+  <span nbBadge>Default</span>
+  <span nbBadge tone="accent">Accent</span>
+  <span nbBadge tone="success">Success</span>
+  <span nbBadge tone="warning">Warning</span>
+  <span nbBadge tone="danger">Danger</span>
+</div>
+```

--- a/skills/ng-brutalism/references/button.md
+++ b/skills/ng-brutalism/references/button.md
@@ -3,46 +3,45 @@
 The neo-brutalist Angular Button component. Displays a button or link that looks like a button, with hard borders, shared tone and shadow tokens, keyboard focus states, and native disabled behavior.
 
 ## Import
+
 ```typescript
-import {
-  NbButton,
-  NbButtonTrailingIcon,
-  NbIcon,
-} from '@ng-brutalism/ui';
+import { NbButton, NbButtonTrailingIcon, NbIcon } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
 
 ### Button (`nbButton`)
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `tone` | `NbToneToken` | `'primary'` | Visual tone of the button. |
-| `shadow` | `'none' \| 'sm' \| 'default' \| 'hard' \| 'heavy'` | `'default'` | Shadow thickness/style. |
-| `press` | `'push' \| 'reverse' \| 'none'` | `'push'` | Visual animation effect when the button is pressed. |
-| `size` | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | Size variant of the button. |
-| `border` | `'none' \| 'thin' \| 'default' \| 'strong' \| 'thick'` | `'default'` | Border thickness variant. |
-| `radius` | `'none' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'` | `'md'` | Border radius variant. |
-| `fullWidth` | `boolean` | `false` | Whether the button should take up the full width of its container. |
+
+| Attribute   | Type                                                   | Default     | Description                                                        |
+| ----------- | ------------------------------------------------------ | ----------- | ------------------------------------------------------------------ |
+| `tone`      | `NbToneToken`                                          | `'primary'` | Visual tone of the button.                                         |
+| `shadow`    | `'none' \| 'sm' \| 'default' \| 'hard' \| 'heavy'`     | `'default'` | Shadow thickness/style.                                            |
+| `press`     | `'push' \| 'reverse' \| 'none'`                        | `'push'`    | Visual animation effect when the button is pressed.                |
+| `size`      | `'sm' \| 'md' \| 'lg' \| 'xl'`                         | `'md'`      | Size variant of the button.                                        |
+| `border`    | `'none' \| 'thin' \| 'default' \| 'strong' \| 'thick'` | `'default'` | Border thickness variant.                                          |
+| `radius`    | `'none' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'`     | `'md'`      | Border radius variant.                                             |
+| `fullWidth` | `boolean`                                              | `false`     | Whether the button should take up the full width of its container. |
 
 ### Trailing Icon (`nbButtonTrailingIcon`)
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `size` | `'sm' \| 'md' \| 'lg'` | `undefined` | Size of the trailing icon wrapper. |
-| `shape` | `'none' \| 'square' \| 'circle'` | `undefined` | Shape of the trailing icon background/container. |
-| `tone` | `'default' \| 'inverse' \| 'current'` | `undefined` | Color tone of the trailing icon wrapper. |
-| `push` | `'none' \| 'end'` | `'none'` | Alignment of the trailing icon (e.g. pushed to the end). |
-| `icon` | `string` | `undefined` | Direct icon source or identifier. |
+
+| Attribute | Type                                  | Default     | Description                                              |
+| --------- | ------------------------------------- | ----------- | -------------------------------------------------------- |
+| `size`    | `'sm' \| 'md' \| 'lg'`                | `undefined` | Size of the trailing icon wrapper.                       |
+| `shape`   | `'none' \| 'square' \| 'circle'`      | `undefined` | Shape of the trailing icon background/container.         |
+| `tone`    | `'default' \| 'inverse' \| 'current'` | `undefined` | Color tone of the trailing icon wrapper.                 |
+| `push`    | `'none' \| 'end'`                     | `'none'`    | Alignment of the trailing icon (e.g. pushed to the end). |
+| `icon`    | `string`                              | `undefined` | Direct icon source or identifier.                        |
 
 ## Usage Examples
 
 ### Default
+
 ```html
-<button nbButton>
-  Button
-</button>
+<button nbButton>Button</button>
 ```
 
 ### Tones
+
 ```html
 <div class="flex flex-wrap items-center justify-center gap-3">
   <button nbButton>Default</button>
@@ -57,6 +56,7 @@ import {
 ```
 
 ### Sizes
+
 ```html
 <div class="flex flex-wrap items-center justify-center gap-3">
   <button nbButton size="sm">Small</button>
@@ -67,11 +67,10 @@ import {
 ```
 
 ### CTA
+
 ```html
 <button nbButton tone="lavender" size="xl" radius="md">
-  <span nbText size="xl" weight="black" transform="uppercase" tracking="wide">
-    Apply Now
-  </span>
+  <span nbText size="xl" weight="black" transform="uppercase" tracking="wide"> Apply Now </span>
   <span nbButtonTrailingIcon shape="circle" tone="inverse" size="md">
     <span nbIcon src="/icons/arrow-right.svg" size="sm" decorative></span>
   </span>
@@ -79,6 +78,7 @@ import {
 ```
 
 ### Trailing Icon
+
 ```html
 <button nbButton tone="secondary">
   Keep Together
@@ -96,15 +96,15 @@ import {
 ```
 
 ### Full Width
+
 ```html
 <div class="w-full max-w-md">
-  <button nbButton [fullWidth]="true">
-    Full width button
-  </button>
+  <button nbButton [fullWidth]="true">Full width button</button>
 </div>
 ```
 
 ### Disabled
+
 ```html
 <div class="flex flex-wrap items-center justify-center gap-4">
   <button nbButton disabled>Disabled button</button>
@@ -113,19 +113,11 @@ import {
 ```
 
 ### Anchor Usage
+
 ```html
 <div class="flex flex-wrap items-center justify-center gap-4">
-  <a nbButton href="https://angular.dev" target="_blank" rel="noreferrer">
-    Angular Docs
-  </a>
+  <a nbButton href="https://angular.dev" target="_blank" rel="noreferrer"> Angular Docs </a>
 
-  <a
-    nbButton
-    href="https://github.com/khangtrannn/ng-brutalism"
-    target="_blank"
-    rel="noreferrer"
-  >
-    GitHub Repo
-  </a>
+  <a nbButton href="https://github.com/khangtrannn/ng-brutalism" target="_blank" rel="noreferrer"> GitHub Repo </a>
 </div>
 ```

--- a/skills/ng-brutalism/references/button.md
+++ b/skills/ng-brutalism/references/button.md
@@ -1,0 +1,131 @@
+# Button
+
+The neo-brutalist Angular Button component. Displays a button or link that looks like a button, with hard borders, shared tone and shadow tokens, keyboard focus states, and native disabled behavior.
+
+## Import
+```typescript
+import {
+  NbButton,
+  NbButtonTrailingIcon,
+  NbIcon,
+} from '@ng-brutalism/ui';
+```
+
+## API Reference
+
+### Button (`nbButton`)
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `tone` | `NbToneToken` | `'primary'` | Visual tone of the button. |
+| `shadow` | `'none' \| 'sm' \| 'default' \| 'hard' \| 'heavy'` | `'default'` | Shadow thickness/style. |
+| `press` | `'push' \| 'reverse' \| 'none'` | `'push'` | Visual animation effect when the button is pressed. |
+| `size` | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | Size variant of the button. |
+| `border` | `'none' \| 'thin' \| 'default' \| 'strong' \| 'thick'` | `'default'` | Border thickness variant. |
+| `radius` | `'none' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'` | `'md'` | Border radius variant. |
+| `fullWidth` | `boolean` | `false` | Whether the button should take up the full width of its container. |
+
+### Trailing Icon (`nbButtonTrailingIcon`)
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `size` | `'sm' \| 'md' \| 'lg'` | `undefined` | Size of the trailing icon wrapper. |
+| `shape` | `'none' \| 'square' \| 'circle'` | `undefined` | Shape of the trailing icon background/container. |
+| `tone` | `'default' \| 'inverse' \| 'current'` | `undefined` | Color tone of the trailing icon wrapper. |
+| `push` | `'none' \| 'end'` | `'none'` | Alignment of the trailing icon (e.g. pushed to the end). |
+| `icon` | `string` | `undefined` | Direct icon source or identifier. |
+
+## Usage Examples
+
+### Default
+```html
+<button nbButton>
+  Button
+</button>
+```
+
+### Tones
+```html
+<div class="flex flex-wrap items-center justify-center gap-3">
+  <button nbButton>Default</button>
+  <button nbButton tone="background">Background</button>
+  <button nbButton tone="primary">Primary</button>
+  <button nbButton tone="secondary">Secondary</button>
+  <button nbButton tone="accent">Accent</button>
+  <button nbButton tone="danger">Danger</button>
+  <button nbButton tone="success">Success</button>
+  <button nbButton tone="warning">Warning</button>
+</div>
+```
+
+### Sizes
+```html
+<div class="flex flex-wrap items-center justify-center gap-3">
+  <button nbButton size="sm">Small</button>
+  <button nbButton size="md">Medium</button>
+  <button nbButton size="lg">Large</button>
+  <button nbButton size="xl">Extra Large</button>
+</div>
+```
+
+### CTA
+```html
+<button nbButton tone="lavender" size="xl" radius="md">
+  <span nbText size="xl" weight="black" transform="uppercase" tracking="wide">
+    Apply Now
+  </span>
+  <span nbButtonTrailingIcon shape="circle" tone="inverse" size="md">
+    <span nbIcon src="/icons/arrow-right.svg" size="sm" decorative></span>
+  </span>
+</button>
+```
+
+### Trailing Icon
+```html
+<button nbButton tone="secondary">
+  Keep Together
+  <span nbButtonTrailingIcon>
+    <span nbIcon src="/icons/arrow-right.svg" size="sm" decorative></span>
+  </span>
+</button>
+
+<button nbButton tone="primary" [fullWidth]="true">
+  Push To End
+  <span nbButtonTrailingIcon push="end" shape="square" size="md">
+    <span nbIcon src="/icons/arrow-right.svg" size="sm" decorative></span>
+  </span>
+</button>
+```
+
+### Full Width
+```html
+<div class="w-full max-w-md">
+  <button nbButton [fullWidth]="true">
+    Full width button
+  </button>
+</div>
+```
+
+### Disabled
+```html
+<div class="flex flex-wrap items-center justify-center gap-4">
+  <button nbButton disabled>Disabled button</button>
+  <a nbButton href="#" aria-disabled="true">Disabled link style</a>
+</div>
+```
+
+### Anchor Usage
+```html
+<div class="flex flex-wrap items-center justify-center gap-4">
+  <a nbButton href="https://angular.dev" target="_blank" rel="noreferrer">
+    Angular Docs
+  </a>
+
+  <a
+    nbButton
+    href="https://github.com/khangtrannn/ng-brutalism"
+    target="_blank"
+    rel="noreferrer"
+  >
+    GitHub Repo
+  </a>
+</div>
+```

--- a/skills/ng-brutalism/references/callout.md
+++ b/skills/ng-brutalism/references/callout.md
@@ -3,29 +3,31 @@
 A high-emphasis directive for important values. Use `nbCallout` for prices, stats, dates, awards, ratings, totals, and other compact pieces of information that need the loud brutalist treatment without domain-specific API.
 
 ## Import
+
 ```typescript
 import { NbCallout, NbSeparator } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `tone` | `'yellow' \| 'pink' \| 'mint' \| 'lavender' \| 'blue' \| 'cream' \| 'white' \| 'black' \| 'primary' \| 'secondary' \| 'accent' \| 'success' \| 'warning' \| 'danger'` | `'yellow'` | Background and foreground color pair. |
-| `size` | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'lg'` | Height, padding, type size, radius, and border weight preset. |
-| `layout` | `'inline' \| 'between' \| 'center'` | `'inline'` | Horizontal alignment for the callout content. |
-| `shadow` | `'none' \| 'default' \| 'hard'` | `'hard'` | Offset shadow preset. |
-| `radius` | `'none' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'` | — | Corner radius override. Defaults to the `size`-derived radius when unset. |
+
+| Attribute | Type                                                                                                                                                                  | Default    | Description                                                               |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------- |
+| `tone`    | `'yellow' \| 'pink' \| 'mint' \| 'lavender' \| 'blue' \| 'cream' \| 'white' \| 'black' \| 'primary' \| 'secondary' \| 'accent' \| 'success' \| 'warning' \| 'danger'` | `'yellow'` | Background and foreground color pair.                                     |
+| `size`    | `'sm' \| 'md' \| 'lg' \| 'xl'`                                                                                                                                        | `'lg'`     | Height, padding, type size, radius, and border weight preset.             |
+| `layout`  | `'inline' \| 'between' \| 'center'`                                                                                                                                   | `'inline'` | Horizontal alignment for the callout content.                             |
+| `shadow`  | `'none' \| 'default' \| 'hard'`                                                                                                                                       | `'hard'`   | Offset shadow preset.                                                     |
+| `radius`  | `'none' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'`                                                                                                                    | —          | Corner radius override. Defaults to the `size`-derived radius when unset. |
 
 ## Usage Examples
 
 ### Default
+
 ```html
-<div nbCallout tone="yellow" size="xl">
-  $799
-</div>
+<div nbCallout tone="yellow" size="xl">$799</div>
 ```
 
 ### Examples
+
 ```html
 <div class="grid w-full grid-cols-1 gap-4 p-4 sm:grid-cols-2">
   <div nbCallout tone="yellow" size="xl">$799</div>
@@ -48,6 +50,7 @@ import { NbCallout, NbSeparator } from '@ng-brutalism/ui';
 ```
 
 ### Tones
+
 ```html
 <div nbCallout tone="yellow">Yellow</div>
 <div nbCallout tone="pink">Pink</div>
@@ -56,6 +59,7 @@ import { NbCallout, NbSeparator } from '@ng-brutalism/ui';
 ```
 
 ### Sizes
+
 ```html
 <div nbCallout size="sm">SM</div>
 <div nbCallout size="md">MD</div>
@@ -64,6 +68,7 @@ import { NbCallout, NbSeparator } from '@ng-brutalism/ui';
 ```
 
 ### Layouts
+
 ```html
 <div nbCallout layout="inline">
   <span>Inline</span>
@@ -82,6 +87,7 @@ import { NbCallout, NbSeparator } from '@ng-brutalism/ui';
 ```
 
 ### Shadows
+
 ```html
 <div nbCallout shadow="none">None</div>
 <div nbCallout shadow="default">Default</div>

--- a/skills/ng-brutalism/references/callout.md
+++ b/skills/ng-brutalism/references/callout.md
@@ -1,0 +1,89 @@
+# Callout
+
+A high-emphasis directive for important values. Use `nbCallout` for prices, stats, dates, awards, ratings, totals, and other compact pieces of information that need the loud brutalist treatment without domain-specific API.
+
+## Import
+```typescript
+import { NbCallout, NbSeparator } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `tone` | `'yellow' \| 'pink' \| 'mint' \| 'lavender' \| 'blue' \| 'cream' \| 'white' \| 'black' \| 'primary' \| 'secondary' \| 'accent' \| 'success' \| 'warning' \| 'danger'` | `'yellow'` | Background and foreground color pair. |
+| `size` | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'lg'` | Height, padding, type size, radius, and border weight preset. |
+| `layout` | `'inline' \| 'between' \| 'center'` | `'inline'` | Horizontal alignment for the callout content. |
+| `shadow` | `'none' \| 'default' \| 'hard'` | `'hard'` | Offset shadow preset. |
+| `radius` | `'none' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'` | — | Corner radius override. Defaults to the `size`-derived radius when unset. |
+
+## Usage Examples
+
+### Default
+```html
+<div nbCallout tone="yellow" size="xl">
+  $799
+</div>
+```
+
+### Examples
+```html
+<div class="grid w-full grid-cols-1 gap-4 p-4 sm:grid-cols-2">
+  <div nbCallout tone="yellow" size="xl">$799</div>
+
+  <div nbCallout tone="pink" size="lg">
+    <span>$420K</span>
+  </div>
+
+  <div nbCallout tone="mint" size="md">
+    <span>4.9</span>
+    <hr nbSeparator orientation="vertical" />
+    <span class="text-sm">842 REVIEWS</span>
+  </div>
+
+  <div nbCallout tone="lavender" size="lg" layout="between">
+    <span>TODAY</span>
+    <span>3:30 PM</span>
+  </div>
+</div>
+```
+
+### Tones
+```html
+<div nbCallout tone="yellow">Yellow</div>
+<div nbCallout tone="pink">Pink</div>
+<div nbCallout tone="mint">Mint</div>
+<div nbCallout tone="black">Black</div>
+```
+
+### Sizes
+```html
+<div nbCallout size="sm">SM</div>
+<div nbCallout size="md">MD</div>
+<div nbCallout size="lg">LG</div>
+<div nbCallout size="xl">XL</div>
+```
+
+### Layouts
+```html
+<div nbCallout layout="inline">
+  <span>Inline</span>
+  <span>EP 42</span>
+</div>
+
+<div nbCallout layout="between">
+  <span>Between</span>
+  <span>EP 42</span>
+</div>
+
+<div nbCallout layout="center">
+  <span>Center</span>
+  <span>EP 42</span>
+</div>
+```
+
+### Shadows
+```html
+<div nbCallout shadow="none">None</div>
+<div nbCallout shadow="default">Default</div>
+<div nbCallout shadow="hard">Hard</div>
+```

--- a/skills/ng-brutalism/references/card.md
+++ b/skills/ng-brutalism/references/card.md
@@ -3,47 +3,44 @@
 The neo-brutalist Angular Card component. A bold content block with header, content, and footer slots wrapped in thick borders and an offset shadow.
 
 ## Import
+
 ```typescript
-import {
-  NbCard,
-  NbCardHeader,
-  NbCardTitle,
-  NbCardDescription,
-  NbCardActions,
-  NbCardContent,
-  NbCardFooter,
-} from '@ng-brutalism/ui';
+import { NbCard, NbCardHeader, NbCardTitle, NbCardDescription, NbCardActions, NbCardContent, NbCardFooter } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
 
 ### Card (`nb-card`)
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `tone` | `NbToneToken` | `'background'` | Background and foreground tone variation. |
-| `radius` | `NbRadius` | `'lg'` | Border radius variant. |
-| `shadow` | `NbShadow` | `'default'` | Shadow thickness/style. |
-| `border` | `NbBorderStrength` | `'default'` | Border thickness/style. |
+
+| Attribute | Type               | Default        | Description                               |
+| --------- | ------------------ | -------------- | ----------------------------------------- |
+| `tone`    | `NbToneToken`      | `'background'` | Background and foreground tone variation. |
+| `radius`  | `NbRadius`         | `'lg'`         | Border radius variant.                    |
+| `shadow`  | `NbShadow`         | `'default'`    | Shadow thickness/style.                   |
+| `border`  | `NbBorderStrength` | `'default'`    | Border thickness/style.                   |
 
 ### Card Actions (`nb-card-actions`)
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `align` | `'start' \| 'end'` | `'start'` | Horizontal alignment of the actions inside the row. |
+
+| Attribute | Type               | Default   | Description                                         |
+| --------- | ------------------ | --------- | --------------------------------------------------- |
+| `align`   | `'start' \| 'end'` | `'start'` | Horizontal alignment of the actions inside the row. |
 
 ### Selectors / Sub-parts
-| Selector | Description |
-|---|---|
-| `nb-card` | Root container with border, shadow, and background. |
-| `nb-card-header` | Top section for title and description content. |
-| `nb-card-title` | Heading text inside the header. |
-| `nb-card-description` | Subtitle or description text inside the header. |
-| `nb-card-actions` | Action row for one or more card-level commands. |
-| `nb-card-content` | Main body area. |
-| `nb-card-footer` | Bottom section for metadata, summaries, and supporting layout. |
+
+| Selector              | Description                                                    |
+| --------------------- | -------------------------------------------------------------- |
+| `nb-card`             | Root container with border, shadow, and background.            |
+| `nb-card-header`      | Top section for title and description content.                 |
+| `nb-card-title`       | Heading text inside the header.                                |
+| `nb-card-description` | Subtitle or description text inside the header.                |
+| `nb-card-actions`     | Action row for one or more card-level commands.                |
+| `nb-card-content`     | Main body area.                                                |
+| `nb-card-footer`      | Bottom section for metadata, summaries, and supporting layout. |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <nb-card>
   <nb-card-header>
@@ -60,18 +57,15 @@ import {
 ```
 
 ### Actions Align End
+
 ```html
 <nb-card class="w-full max-w-sm">
   <nb-card-header>
     <nb-card-title>Notifications</nb-card-title>
-    <nb-card-description>
-      You have 3 unread messages.
-    </nb-card-description>
+    <nb-card-description> You have 3 unread messages. </nb-card-description>
   </nb-card-header>
   <nb-card-content>
-    <p class="text-sm">
-      Check your inbox for the latest updates from your team.
-    </p>
+    <p class="text-sm">Check your inbox for the latest updates from your team.</p>
   </nb-card-content>
   <nb-card-actions align="end">
     <button nbButton size="sm" tone="background">Mark all read</button>
@@ -81,6 +75,7 @@ import {
 ```
 
 ### Footer with Metadata and Actions
+
 ```html
 <nb-card class="w-full max-w-xl">
   <nb-card-header>
@@ -88,9 +83,7 @@ import {
     <nb-card-description>Inspectorio</nb-card-description>
   </nb-card-header>
   <nb-card-content>
-    <p class="text-sm">
-      Build delightful UI systems and scalable web experiences.
-    </p>
+    <p class="text-sm">Build delightful UI systems and scalable web experiences.</p>
   </nb-card-content>
   <nb-card-footer class="border-t">
     <div class="space-y-2 text-sm">

--- a/skills/ng-brutalism/references/card.md
+++ b/skills/ng-brutalism/references/card.md
@@ -1,0 +1,106 @@
+# Card
+
+The neo-brutalist Angular Card component. A bold content block with header, content, and footer slots wrapped in thick borders and an offset shadow.
+
+## Import
+```typescript
+import {
+  NbCard,
+  NbCardHeader,
+  NbCardTitle,
+  NbCardDescription,
+  NbCardActions,
+  NbCardContent,
+  NbCardFooter,
+} from '@ng-brutalism/ui';
+```
+
+## API Reference
+
+### Card (`nb-card`)
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `tone` | `NbToneToken` | `'background'` | Background and foreground tone variation. |
+| `radius` | `NbRadius` | `'lg'` | Border radius variant. |
+| `shadow` | `NbShadow` | `'default'` | Shadow thickness/style. |
+| `border` | `NbBorderStrength` | `'default'` | Border thickness/style. |
+
+### Card Actions (`nb-card-actions`)
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `align` | `'start' \| 'end'` | `'start'` | Horizontal alignment of the actions inside the row. |
+
+### Selectors / Sub-parts
+| Selector | Description |
+|---|---|
+| `nb-card` | Root container with border, shadow, and background. |
+| `nb-card-header` | Top section for title and description content. |
+| `nb-card-title` | Heading text inside the header. |
+| `nb-card-description` | Subtitle or description text inside the header. |
+| `nb-card-actions` | Action row for one or more card-level commands. |
+| `nb-card-content` | Main body area. |
+| `nb-card-footer` | Bottom section for metadata, summaries, and supporting layout. |
+
+## Usage Examples
+
+### Default
+```html
+<nb-card>
+  <nb-card-header>
+    <nb-card-title>Card Title</nb-card-title>
+    <nb-card-description>Card Description</nb-card-description>
+  </nb-card-header>
+  <nb-card-content>
+    <p>Card Content</p>
+  </nb-card-content>
+  <nb-card-actions>
+    <button nbButton>Action</button>
+  </nb-card-actions>
+</nb-card>
+```
+
+### Actions Align End
+```html
+<nb-card class="w-full max-w-sm">
+  <nb-card-header>
+    <nb-card-title>Notifications</nb-card-title>
+    <nb-card-description>
+      You have 3 unread messages.
+    </nb-card-description>
+  </nb-card-header>
+  <nb-card-content>
+    <p class="text-sm">
+      Check your inbox for the latest updates from your team.
+    </p>
+  </nb-card-content>
+  <nb-card-actions align="end">
+    <button nbButton size="sm" tone="background">Mark all read</button>
+    <button nbButton size="sm">Open inbox</button>
+  </nb-card-actions>
+</nb-card>
+```
+
+### Footer with Metadata and Actions
+```html
+<nb-card class="w-full max-w-xl">
+  <nb-card-header>
+    <nb-card-title>Senior Frontend Engineer</nb-card-title>
+    <nb-card-description>Inspectorio</nb-card-description>
+  </nb-card-header>
+  <nb-card-content>
+    <p class="text-sm">
+      Build delightful UI systems and scalable web experiences.
+    </p>
+  </nb-card-content>
+  <nb-card-footer class="border-t">
+    <div class="space-y-2 text-sm">
+      <p>Ho Chi Minh City / Remote</p>
+      <p>Posted 2 days ago</p>
+    </div>
+    <nb-card-actions align="end">
+      <button nbButton>Apply</button>
+      <button nbButton tone="primary">Save</button>
+    </nb-card-actions>
+  </nb-card-footer>
+</nb-card>
+```

--- a/skills/ng-brutalism/references/checkbox.md
+++ b/skills/ng-brutalism/references/checkbox.md
@@ -1,0 +1,45 @@
+# Checkbox
+
+The neo-brutalist Angular Checkbox component. A control that allows the user to toggle between checked and not checked in the brutalist style with strong focus states.
+
+## Import
+```typescript
+import { NbCheckbox } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Size variant of the checkbox. |
+
+## Usage Examples
+
+### Default
+```html
+<input type="checkbox" nbCheckbox />
+```
+
+### Sizes
+```html
+<div class="flex items-center gap-4">
+  <input type="checkbox" nbCheckbox size="sm" />
+  <input type="checkbox" nbCheckbox />
+  <input type="checkbox" nbCheckbox size="lg" />
+</div>
+```
+
+### Disabled
+```html
+<div class="flex items-center gap-4">
+  <input type="checkbox" nbCheckbox disabled />
+  <input type="checkbox" nbCheckbox disabled checked />
+</div>
+```
+
+### With Label
+```html
+<div class="flex items-center gap-2">
+  <input type="checkbox" nbCheckbox id="terms" />
+  <label nbLabel for="terms">Accept terms and conditions</label>
+</div>
+```

--- a/skills/ng-brutalism/references/checkbox.md
+++ b/skills/ng-brutalism/references/checkbox.md
@@ -3,23 +3,27 @@
 The neo-brutalist Angular Checkbox component. A control that allows the user to toggle between checked and not checked in the brutalist style with strong focus states.
 
 ## Import
+
 ```typescript
 import { NbCheckbox } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Size variant of the checkbox. |
+
+| Attribute | Type                   | Default | Description                   |
+| --------- | ---------------------- | ------- | ----------------------------- |
+| `size`    | `'sm' \| 'md' \| 'lg'` | `'md'`  | Size variant of the checkbox. |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <input type="checkbox" nbCheckbox />
 ```
 
 ### Sizes
+
 ```html
 <div class="flex items-center gap-4">
   <input type="checkbox" nbCheckbox size="sm" />
@@ -29,6 +33,7 @@ import { NbCheckbox } from '@ng-brutalism/ui';
 ```
 
 ### Disabled
+
 ```html
 <div class="flex items-center gap-4">
   <input type="checkbox" nbCheckbox disabled />
@@ -37,6 +42,7 @@ import { NbCheckbox } from '@ng-brutalism/ui';
 ```
 
 ### With Label
+
 ```html
 <div class="flex items-center gap-2">
   <input type="checkbox" nbCheckbox id="terms" />

--- a/skills/ng-brutalism/references/chip.md
+++ b/skills/ng-brutalism/references/chip.md
@@ -3,6 +3,7 @@
 A directive on `<span>` for compact labels, tags, and categories. Pairs with `nbChipGroup` for horizontal chip rows. Supports 10 tones and an optional leading icon via `ng-content`.
 
 ## Import
+
 ```typescript
 import { NbChip, NbChipGroup } from '@ng-brutalism/ui';
 ```
@@ -10,30 +11,34 @@ import { NbChip, NbChipGroup } from '@ng-brutalism/ui';
 ## API Reference
 
 ### Chip (`nbChip`)
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `tone` | `'default' \| 'ink' \| 'yellow' \| 'pink' \| 'mint' \| 'lavender' \| 'accent' \| 'success' \| 'warning' \| 'danger'` | `'default'` | Background color tone. |
-| `padding` | `'none' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | Inner padding scale. |
-| `radius` | `'none' \| 'sm' \| 'md' \| 'lg' \| 'full'` | `'none'` | Corner radius scale. |
-| `shadow` | `'none' \| 'sm' \| 'default' \| 'hard'` | `'sm'` | Drop shadow scale. |
-| `icon` | `string` | — | URL of a leading SVG icon, tinted to the chip's foreground via `nbIcon` mask mode. |
-| `iconSize` | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'sm'` | Size of the `icon` input's icon. |
+
+| Attribute  | Type                                                                                                                 | Default     | Description                                                                        |
+| ---------- | -------------------------------------------------------------------------------------------------------------------- | ----------- | ---------------------------------------------------------------------------------- |
+| `tone`     | `'default' \| 'ink' \| 'yellow' \| 'pink' \| 'mint' \| 'lavender' \| 'accent' \| 'success' \| 'warning' \| 'danger'` | `'default'` | Background color tone.                                                             |
+| `padding`  | `'none' \| 'sm' \| 'md' \| 'lg' \| 'xl'`                                                                             | `'md'`      | Inner padding scale.                                                               |
+| `radius`   | `'none' \| 'sm' \| 'md' \| 'lg' \| 'full'`                                                                           | `'none'`    | Corner radius scale.                                                               |
+| `shadow`   | `'none' \| 'sm' \| 'default' \| 'hard'`                                                                              | `'sm'`      | Drop shadow scale.                                                                 |
+| `icon`     | `string`                                                                                                             | —           | URL of a leading SVG icon, tinted to the chip's foreground via `nbIcon` mask mode. |
+| `iconSize` | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'`                                                                               | `'sm'`      | Size of the `icon` input's icon.                                                   |
 
 ### Chip Group (`nbChipGroup`)
+
 Wrapper directive with `flex flex-wrap gap-2`. No inputs — use Tailwind or inline styles to override spacing.
 
 ### CSS Custom Properties (Variables)
-| Custom Property | Default | Description |
-|---|---|---|
-| `--nb-chip-bg` | `var(--nb-surface)` | Background color. |
-| `--nb-chip-fg` | `var(--nb-foreground)` | Text and icon color. |
-| `--nb-chip-radius` | `0px` | Corner radius. |
-| `--nb-chip-shadow` | `2px 2px 0 0 var(--nb-shadow)` | Box shadow. |
-| `--nb-chip-icon-size` | `0.75rem` | Projected SVG size. |
+
+| Custom Property       | Default                        | Description          |
+| --------------------- | ------------------------------ | -------------------- |
+| `--nb-chip-bg`        | `var(--nb-surface)`            | Background color.    |
+| `--nb-chip-fg`        | `var(--nb-foreground)`         | Text and icon color. |
+| `--nb-chip-radius`    | `0px`                          | Corner radius.       |
+| `--nb-chip-shadow`    | `2px 2px 0 0 var(--nb-shadow)` | Box shadow.          |
+| `--nb-chip-icon-size` | `0.75rem`                      | Projected SVG size.  |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <div nbChipGroup>
   <span nbChip>Angular</span>
@@ -44,6 +49,7 @@ Wrapper directive with `flex flex-wrap gap-2`. No inputs — use Tailwind or inl
 ```
 
 ### Tones
+
 ```html
 <div nbChipGroup>
   <span nbChip>default</span>
@@ -60,13 +66,9 @@ Wrapper directive with `flex flex-wrap gap-2`. No inputs — use Tailwind or inl
 ```
 
 ### Tokens (Custom Styling)
+
 ```html
-<span
-  nbChip
-  tone="yellow"
-  class="gap-[14px] px-[18px] py-[10px] text-[22px] leading-none font-black"
-  style="--nb-chip-radius:8px; --nb-chip-shadow:6px 6px 0 0 var(--nb-shadow); --nb-chip-icon-size:36px"
->
+<span nbChip tone="yellow" class="gap-[14px] px-[18px] py-[10px] text-[22px] leading-none font-black" style="--nb-chip-radius:8px; --nb-chip-shadow:6px 6px 0 0 var(--nb-shadow); --nb-chip-icon-size:36px">
   <svg viewBox="0 0 40 40" fill="none" aria-hidden="true">
     <circle cx="20" cy="20" r="18" fill="currentColor" />
     <text x="20" y="27" text-anchor="middle" font-size="24" font-weight="1000" fill="#fff" font-family="Arial Black, Arial, sans-serif">$</text>
@@ -76,6 +78,7 @@ Wrapper directive with `flex flex-wrap gap-2`. No inputs — use Tailwind or inl
 ```
 
 ### With Icon
+
 ```html
 <div nbChipGroup>
   <span nbChip tone="mint" icon="/podcast-card/clock.svg">45 MIN</span>

--- a/skills/ng-brutalism/references/chip.md
+++ b/skills/ng-brutalism/references/chip.md
@@ -1,0 +1,84 @@
+# Chip
+
+A directive on `<span>` for compact labels, tags, and categories. Pairs with `nbChipGroup` for horizontal chip rows. Supports 10 tones and an optional leading icon via `ng-content`.
+
+## Import
+```typescript
+import { NbChip, NbChipGroup } from '@ng-brutalism/ui';
+```
+
+## API Reference
+
+### Chip (`nbChip`)
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `tone` | `'default' \| 'ink' \| 'yellow' \| 'pink' \| 'mint' \| 'lavender' \| 'accent' \| 'success' \| 'warning' \| 'danger'` | `'default'` | Background color tone. |
+| `padding` | `'none' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | Inner padding scale. |
+| `radius` | `'none' \| 'sm' \| 'md' \| 'lg' \| 'full'` | `'none'` | Corner radius scale. |
+| `shadow` | `'none' \| 'sm' \| 'default' \| 'hard'` | `'sm'` | Drop shadow scale. |
+| `icon` | `string` | — | URL of a leading SVG icon, tinted to the chip's foreground via `nbIcon` mask mode. |
+| `iconSize` | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'sm'` | Size of the `icon` input's icon. |
+
+### Chip Group (`nbChipGroup`)
+Wrapper directive with `flex flex-wrap gap-2`. No inputs — use Tailwind or inline styles to override spacing.
+
+### CSS Custom Properties (Variables)
+| Custom Property | Default | Description |
+|---|---|---|
+| `--nb-chip-bg` | `var(--nb-surface)` | Background color. |
+| `--nb-chip-fg` | `var(--nb-foreground)` | Text and icon color. |
+| `--nb-chip-radius` | `0px` | Corner radius. |
+| `--nb-chip-shadow` | `2px 2px 0 0 var(--nb-shadow)` | Box shadow. |
+| `--nb-chip-icon-size` | `0.75rem` | Projected SVG size. |
+
+## Usage Examples
+
+### Default
+```html
+<div nbChipGroup>
+  <span nbChip>Angular</span>
+  <span nbChip tone="mint">TypeScript</span>
+  <span nbChip tone="pink">RxJS</span>
+  <span nbChip tone="lavender">Signals</span>
+</div>
+```
+
+### Tones
+```html
+<div nbChipGroup>
+  <span nbChip>default</span>
+  <span nbChip tone="ink">ink</span>
+  <span nbChip tone="yellow">yellow</span>
+  <span nbChip tone="pink">pink</span>
+  <span nbChip tone="mint">mint</span>
+  <span nbChip tone="lavender">lavender</span>
+  <span nbChip tone="accent">accent</span>
+  <span nbChip tone="success">success</span>
+  <span nbChip tone="warning">warning</span>
+  <span nbChip tone="danger">danger</span>
+</div>
+```
+
+### Tokens (Custom Styling)
+```html
+<span
+  nbChip
+  tone="yellow"
+  class="gap-[14px] px-[18px] py-[10px] text-[22px] leading-none font-black"
+  style="--nb-chip-radius:8px; --nb-chip-shadow:6px 6px 0 0 var(--nb-shadow); --nb-chip-icon-size:36px"
+>
+  <svg viewBox="0 0 40 40" fill="none" aria-hidden="true">
+    <circle cx="20" cy="20" r="18" fill="currentColor" />
+    <text x="20" y="27" text-anchor="middle" font-size="24" font-weight="1000" fill="#fff" font-family="Arial Black, Arial, sans-serif">$</text>
+  </svg>
+  $95K - $130K
+</span>
+```
+
+### With Icon
+```html
+<div nbChipGroup>
+  <span nbChip tone="mint" icon="/podcast-card/clock.svg">45 MIN</span>
+  <span nbChip tone="lavender" icon="/podcast-card/sparkle.svg">NEW</span>
+</div>
+```

--- a/skills/ng-brutalism/references/cluster.md
+++ b/skills/ng-brutalism/references/cluster.md
@@ -3,23 +3,26 @@
 Use `nbCluster` whenever children should flow horizontally, align together, and wrap cleanly on smaller screens. It is the inline composition pair to `nbStack`.
 
 ## Import
+
 ```typescript
 import { NbCluster } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `gap` | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| '2xl'` | `'md'` | Horizontal and wrapped-row spacing between cluster children. |
-| `padding` | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'none'` | Uniform inner padding around the cluster's children. |
-| `align` | `'start' \| 'center' \| 'end' \| 'baseline' \| 'stretch'` | `'center'` | Cross-axis alignment for the inline group. |
-| `justify` | `'start' \| 'center' \| 'end' \| 'between'` | `'start'` | Main-axis distribution when the cluster has extra width. |
-| `wrap` | `'wrap' \| 'nowrap'` | `'wrap'` | Controls whether children can wrap onto additional rows. |
-| `separator` | `'none' \| 'solid' \| 'dashed' \| 'thick'` | `'none'` | Inline-start border between each child. When active, `gap-x` is collapsed and spacing is split across separator margin and padding. |
+
+| Attribute   | Type                                                      | Default    | Description                                                                                                                         |
+| ----------- | --------------------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `gap`       | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| '2xl'` | `'md'`     | Horizontal and wrapped-row spacing between cluster children.                                                                        |
+| `padding`   | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'`          | `'none'`   | Uniform inner padding around the cluster's children.                                                                                |
+| `align`     | `'start' \| 'center' \| 'end' \| 'baseline' \| 'stretch'` | `'center'` | Cross-axis alignment for the inline group.                                                                                          |
+| `justify`   | `'start' \| 'center' \| 'end' \| 'between'`               | `'start'`  | Main-axis distribution when the cluster has extra width.                                                                            |
+| `wrap`      | `'wrap' \| 'nowrap'`                                      | `'wrap'`   | Controls whether children can wrap onto additional rows.                                                                            |
+| `separator` | `'none' \| 'solid' \| 'dashed' \| 'thick'`                | `'none'`   | Inline-start border between each child. When active, `gap-x` is collapsed and spacing is split across separator margin and padding. |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <div nbCluster gap="2xl" align="center" justify="center">
   <div>
@@ -41,6 +44,7 @@ import { NbCluster } from '@ng-brutalism/ui';
 ```
 
 ### Gaps
+
 ```html
 <div nbCluster gap="none">...</div>
 <div nbCluster gap="xs">...</div>
@@ -52,6 +56,7 @@ import { NbCluster } from '@ng-brutalism/ui';
 ```
 
 ### Alignment
+
 ```html
 <div nbCluster align="start">...</div>
 <div nbCluster align="center">...</div>
@@ -61,6 +66,7 @@ import { NbCluster } from '@ng-brutalism/ui';
 ```
 
 ### Justification
+
 ```html
 <div nbCluster justify="start">...</div>
 <div nbCluster justify="center">...</div>
@@ -69,17 +75,15 @@ import { NbCluster } from '@ng-brutalism/ui';
 ```
 
 ### Wrapping
-```html
-<div nbCluster gap="md">
-  ...
-</div>
 
-<div nbCluster gap="md" wrap="nowrap">
-  ...
-</div>
+```html
+<div nbCluster gap="md">...</div>
+
+<div nbCluster gap="md" wrap="nowrap">...</div>
 ```
 
 ### Separators
+
 ```html
 <div nbCluster gap="lg" align="center" separator="dashed">
   <nb-media-item icon="/icons/location.png">
@@ -95,12 +99,7 @@ import { NbCluster } from '@ng-brutalism/ui';
 ```
 
 ### Responsive Gap
+
 ```html
-<div
-  nbCluster
-  gap="md"
-  class="md:[--nb-cluster-gap:1.5rem]"
->
-  ...
-</div>
+<div nbCluster gap="md" class="md:[--nb-cluster-gap:1.5rem]">...</div>
 ```

--- a/skills/ng-brutalism/references/cluster.md
+++ b/skills/ng-brutalism/references/cluster.md
@@ -1,0 +1,106 @@
+# Cluster
+
+Use `nbCluster` whenever children should flow horizontally, align together, and wrap cleanly on smaller screens. It is the inline composition pair to `nbStack`.
+
+## Import
+```typescript
+import { NbCluster } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `gap` | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| '2xl'` | `'md'` | Horizontal and wrapped-row spacing between cluster children. |
+| `padding` | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'none'` | Uniform inner padding around the cluster's children. |
+| `align` | `'start' \| 'center' \| 'end' \| 'baseline' \| 'stretch'` | `'center'` | Cross-axis alignment for the inline group. |
+| `justify` | `'start' \| 'center' \| 'end' \| 'between'` | `'start'` | Main-axis distribution when the cluster has extra width. |
+| `wrap` | `'wrap' \| 'nowrap'` | `'wrap'` | Controls whether children can wrap onto additional rows. |
+| `separator` | `'none' \| 'solid' \| 'dashed' \| 'thick'` | `'none'` | Inline-start border between each child. When active, `gap-x` is collapsed and spacing is split across separator margin and padding. |
+
+## Usage Examples
+
+### Default
+```html
+<div nbCluster gap="2xl" align="center" justify="center">
+  <div>
+    <div>NB</div>
+    <button nbButton size="lg">Ship it</button>
+  </div>
+
+  <div>
+    <div nbCluster gap="sm" justify="center">
+      <span>Logo</span>
+      <span>Actions</span>
+      <span>Badges</span>
+    </div>
+
+    <h2 nbDisplay>Cluster loud.</h2>
+    <p>Inline rhythm for logos, actions, badges, and feature rows.</p>
+  </div>
+</div>
+```
+
+### Gaps
+```html
+<div nbCluster gap="none">...</div>
+<div nbCluster gap="xs">...</div>
+<div nbCluster gap="sm">...</div>
+<div nbCluster gap="md">...</div>
+<div nbCluster gap="lg">...</div>
+<div nbCluster gap="xl">...</div>
+<div nbCluster gap="2xl">...</div>
+```
+
+### Alignment
+```html
+<div nbCluster align="start">...</div>
+<div nbCluster align="center">...</div>
+<div nbCluster align="end">...</div>
+<div nbCluster align="baseline">...</div>
+<div nbCluster align="stretch">...</div>
+```
+
+### Justification
+```html
+<div nbCluster justify="start">...</div>
+<div nbCluster justify="center">...</div>
+<div nbCluster justify="end">...</div>
+<div nbCluster justify="between">...</div>
+```
+
+### Wrapping
+```html
+<div nbCluster gap="md">
+  ...
+</div>
+
+<div nbCluster gap="md" wrap="nowrap">
+  ...
+</div>
+```
+
+### Separators
+```html
+<div nbCluster gap="lg" align="center" separator="dashed">
+  <nb-media-item icon="/icons/location.png">
+    <span nbMediaItemTitle>Central<br />Locations</span>
+  </nb-media-item>
+  <nb-media-item icon="/icons/guide.png">
+    <span nbMediaItemTitle>Guided<br />Experiences</span>
+  </nb-media-item>
+  <nb-media-item icon="/icons/support.png">
+    <span nbMediaItemTitle>24/7<br />Support</span>
+  </nb-media-item>
+</div>
+```
+
+### Responsive Gap
+```html
+<div
+  nbCluster
+  gap="md"
+  class="md:[--nb-cluster-gap:1.5rem]"
+>
+  ...
+</div>
+```

--- a/skills/ng-brutalism/references/common-patterns.md
+++ b/skills/ng-brutalism/references/common-patterns.md
@@ -1,0 +1,133 @@
+# Common Patterns
+
+Copy-pasteable composition patterns built from ng-brutalism primitives. Each pattern shows the rendered output and the template — adjust tones, radii, and gaps to fit your context.
+
+## Usage Examples
+
+### Brutalist Card Shell
+```html
+<article nbSurface tone="cream" radius="xl" shadow="hard" border="strong" clip>
+  <header nbSection padding="lg" divider="bottom">
+    <div nbCluster gap="sm" align="center" justify="between">
+      <h2 nbDisplay size="sm" underline="bar" underlineGap="xs" class="inline-flex flex-col items-start" style="--nb-underline-width: 45%">Card title</h2>
+      <span nbChip tone="mint">Active</span>
+    </div>
+  </header>
+
+  <div nbSection padding="lg">
+    <div nbStack gap="md">
+      <p nbText>Card content goes here.</p>
+      <div nbCluster gap="xs">
+        <span nbChip tone="yellow">Tag one</span>
+        <span nbChip tone="pink">Tag two</span>
+      </div>
+    </div>
+  </div>
+
+  <footer nbSection padding="lg" divider="top" layout="between" align="center">
+    <span nbText tone="muted">Meta info</span>
+    <button nbButton tone="yellow">Action</button>
+  </footer>
+</article>
+```
+
+### Toolbar Row
+```html
+<div nbCluster gap="sm" align="center" justify="between">
+  <h2 nbDisplay size="sm" underline="bar" underlineGap="xs" class="inline-flex flex-col items-start" style="--nb-underline-width: 45%">Components</h2>
+
+  <div nbCluster gap="xs">
+    <button nbButton size="sm" tone="white">Copy</button>
+    <button nbButton size="sm" tone="black">Open</button>
+  </div>
+</div>
+```
+
+### Feature Card Stack
+```html
+<div nbCluster gap="md">
+  <article nbSurface tone="yellow" padding="lg" radius="lg"
+           shadow="hard" border="strong" class="flex-1 min-w-[160px]">
+    <div nbStack gap="xs">
+      <h3 nbText size="2xl" weight="black" leading="tight" underline="bar" underlineGap="xs" style="--nb-underline-width: 45%">Angular native</h3>
+      <p nbText size="sm">Directive APIs, signal inputs.</p>
+    </div>
+  </article>
+
+  <article nbSurface tone="mint" padding="lg" radius="lg"
+           shadow="hard" border="strong" class="flex-1 min-w-[160px]">
+    <div nbStack gap="xs">
+      <h3 nbText size="2xl" weight="black" leading="tight" underline="bar" underlineGap="xs" style="--nb-underline-width: 45%">Loud by default</h3>
+      <p nbText size="sm">Chunky borders, punchy color.</p>
+    </div>
+  </article>
+
+  <article nbSurface tone="pink" padding="lg" radius="lg"
+           shadow="hard" border="strong" class="flex-1 min-w-[160px]">
+    <div nbStack gap="xs">
+      <h3 nbText size="2xl" weight="black" leading="tight" underline="bar" underlineGap="xs" style="--nb-underline-width: 45%">Token driven</h3>
+      <p nbText size="sm">CSS variables keep overrides local.</p>
+    </div>
+  </article>
+</div>
+```
+
+### Callout Panel
+```html
+<article nbSurface tone="cream" radius="xl" shadow="hard" border="strong" clip>
+  <header nbSection padding="lg" divider="bottom">
+    <div nbCluster gap="sm" align="center" justify="between">
+      <h2 nbDisplay size="sm" underline="bar" underlineGap="xs" class="inline-flex flex-col items-start" style="--nb-underline-width: 45%">Pricing</h2>
+      <span nbChip tone="yellow">Early access</span>
+    </div>
+  </header>
+
+  <div nbSection padding="lg">
+    <div nbStack gap="lg">
+      <div nbCallout tone="yellow" size="xl" shadow="hard">$49/mo</div>
+      <p nbText>
+        Everything included. No usage limits. Cancel any time.
+      </p>
+      <button nbButton tone="black" size="lg">Start free trial</button>
+    </div>
+  </div>
+</article>
+```
+
+### Two-Column Card
+```html
+<article nbSurface tone="lavender" radius="xl"
+         shadow="hard" border="strong" clip>
+  <div nbSection padding="lg">
+    <div nbSplit ratio="1:2" gap="lg" collapse="sm" align="center">
+      <!-- Stat or media placeholder -->
+      <div>42</div>
+
+      <div nbStack gap="xs">
+        <h2 nbDisplay size="sm" underline="bar" underlineGap="xs" class="inline-flex flex-col items-start" style="--nb-underline-width: 45%">Components shipped</h2>
+        <p nbText tone="muted" size="sm">
+          Fully composed, keyboard-ready, token-driven.
+        </p>
+      </div>
+    </div>
+  </div>
+</article>
+```
+
+### Primitives Used Panel
+```html
+<section nbSurface tone="cream" padding="lg"
+         radius="xl" shadow="hard" border="strong">
+  <div nbStack gap="md">
+    <h2 nbDisplay size="sm" underline="bar" underlineGap="xs" class="inline-flex flex-col items-start" style="--nb-underline-width: 45%">Primitives used</h2>
+
+    <div nbCluster gap="xs">
+      <span nbChip tone="yellow">nbSurface</span>
+      <span nbChip tone="pink">nbSection</span>
+      <span nbChip tone="mint">nbSplit</span>
+      <span nbChip tone="lavender">nbStack</span>
+      <span nbChip tone="blue">nbCluster</span>
+    </div>
+  </div>
+</section>
+```

--- a/skills/ng-brutalism/references/common-patterns.md
+++ b/skills/ng-brutalism/references/common-patterns.md
@@ -5,6 +5,7 @@ Copy-pasteable composition patterns built from ng-brutalism primitives. Each pat
 ## Usage Examples
 
 ### Brutalist Card Shell
+
 ```html
 <article nbSurface tone="cream" radius="xl" shadow="hard" border="strong" clip>
   <header nbSection padding="lg" divider="bottom">
@@ -32,6 +33,7 @@ Copy-pasteable composition patterns built from ng-brutalism primitives. Each pat
 ```
 
 ### Toolbar Row
+
 ```html
 <div nbCluster gap="sm" align="center" justify="between">
   <h2 nbDisplay size="sm" underline="bar" underlineGap="xs" class="inline-flex flex-col items-start" style="--nb-underline-width: 45%">Components</h2>
@@ -44,26 +46,24 @@ Copy-pasteable composition patterns built from ng-brutalism primitives. Each pat
 ```
 
 ### Feature Card Stack
+
 ```html
 <div nbCluster gap="md">
-  <article nbSurface tone="yellow" padding="lg" radius="lg"
-           shadow="hard" border="strong" class="flex-1 min-w-[160px]">
+  <article nbSurface tone="yellow" padding="lg" radius="lg" shadow="hard" border="strong" class="flex-1 min-w-[160px]">
     <div nbStack gap="xs">
       <h3 nbText size="2xl" weight="black" leading="tight" underline="bar" underlineGap="xs" style="--nb-underline-width: 45%">Angular native</h3>
       <p nbText size="sm">Directive APIs, signal inputs.</p>
     </div>
   </article>
 
-  <article nbSurface tone="mint" padding="lg" radius="lg"
-           shadow="hard" border="strong" class="flex-1 min-w-[160px]">
+  <article nbSurface tone="mint" padding="lg" radius="lg" shadow="hard" border="strong" class="flex-1 min-w-[160px]">
     <div nbStack gap="xs">
       <h3 nbText size="2xl" weight="black" leading="tight" underline="bar" underlineGap="xs" style="--nb-underline-width: 45%">Loud by default</h3>
       <p nbText size="sm">Chunky borders, punchy color.</p>
     </div>
   </article>
 
-  <article nbSurface tone="pink" padding="lg" radius="lg"
-           shadow="hard" border="strong" class="flex-1 min-w-[160px]">
+  <article nbSurface tone="pink" padding="lg" radius="lg" shadow="hard" border="strong" class="flex-1 min-w-[160px]">
     <div nbStack gap="xs">
       <h3 nbText size="2xl" weight="black" leading="tight" underline="bar" underlineGap="xs" style="--nb-underline-width: 45%">Token driven</h3>
       <p nbText size="sm">CSS variables keep overrides local.</p>
@@ -73,6 +73,7 @@ Copy-pasteable composition patterns built from ng-brutalism primitives. Each pat
 ```
 
 ### Callout Panel
+
 ```html
 <article nbSurface tone="cream" radius="xl" shadow="hard" border="strong" clip>
   <header nbSection padding="lg" divider="bottom">
@@ -85,9 +86,7 @@ Copy-pasteable composition patterns built from ng-brutalism primitives. Each pat
   <div nbSection padding="lg">
     <div nbStack gap="lg">
       <div nbCallout tone="yellow" size="xl" shadow="hard">$49/mo</div>
-      <p nbText>
-        Everything included. No usage limits. Cancel any time.
-      </p>
+      <p nbText>Everything included. No usage limits. Cancel any time.</p>
       <button nbButton tone="black" size="lg">Start free trial</button>
     </div>
   </div>
@@ -95,9 +94,9 @@ Copy-pasteable composition patterns built from ng-brutalism primitives. Each pat
 ```
 
 ### Two-Column Card
+
 ```html
-<article nbSurface tone="lavender" radius="xl"
-         shadow="hard" border="strong" clip>
+<article nbSurface tone="lavender" radius="xl" shadow="hard" border="strong" clip>
   <div nbSection padding="lg">
     <div nbSplit ratio="1:2" gap="lg" collapse="sm" align="center">
       <!-- Stat or media placeholder -->
@@ -105,9 +104,7 @@ Copy-pasteable composition patterns built from ng-brutalism primitives. Each pat
 
       <div nbStack gap="xs">
         <h2 nbDisplay size="sm" underline="bar" underlineGap="xs" class="inline-flex flex-col items-start" style="--nb-underline-width: 45%">Components shipped</h2>
-        <p nbText tone="muted" size="sm">
-          Fully composed, keyboard-ready, token-driven.
-        </p>
+        <p nbText tone="muted" size="sm">Fully composed, keyboard-ready, token-driven.</p>
       </div>
     </div>
   </div>
@@ -115,9 +112,9 @@ Copy-pasteable composition patterns built from ng-brutalism primitives. Each pat
 ```
 
 ### Primitives Used Panel
+
 ```html
-<section nbSurface tone="cream" padding="lg"
-         radius="xl" shadow="hard" border="strong">
+<section nbSurface tone="cream" padding="lg" radius="xl" shadow="hard" border="strong">
   <div nbStack gap="md">
     <h2 nbDisplay size="sm" underline="bar" underlineGap="xs" class="inline-flex flex-col items-start" style="--nb-underline-width: 45%">Primitives used</h2>
 

--- a/skills/ng-brutalism/references/dialog.md
+++ b/skills/ng-brutalism/references/dialog.md
@@ -1,0 +1,164 @@
+# Dialog
+
+The neo-brutalist Angular Dialog component — a brutalist modal built on the native `<dialog>` element. Compound API with SSR-safe open/close. Click the backdrop to dismiss.
+
+## Import
+```typescript
+import {
+  NbButton,
+  NbDialog,
+  NbDialogTitle,
+  NbDialogDescription,
+  NbDialogContent,
+  NbDialogActions,
+  NbDialogClose,
+  NbIconButton,
+  NbTitle,
+  NbInput,
+  NbInputGroup,
+  NbInputPrefix,
+  NbLabel,
+  NbSelect,
+  NbSelectOption,
+  NbTextarea,
+} from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Part | Description |
+|---|---|
+| `nb-dialog` | Root component. Renders the native `<dialog>` modal. Exposes `open()` and `close()` for `viewChild` access. |
+| `[nbDialogTitle]` | Directive applied to a heading element. Styles the dialog title. |
+| `[nbDialogDescription]` | Directive for muted supporting text below the title. |
+| `nb-dialog-content` | Scrollable body section with top and bottom borders. |
+| `nb-dialog-actions` | Footer section with right-aligned action buttons. |
+| `[nbDialogClose]` | Directive that closes the dialog on click. |
+
+## Usage Examples
+
+### Default
+```html
+<button nbButton (click)="dialog.open()">Open Dialog</button>
+
+<nb-dialog #dialog>
+  <div class="relative p-6">
+    <button
+      nbIconButton
+      nbDialogClose
+      tone="background"
+      radius="md"
+      aria-label="Close dialog"
+      class="absolute right-6 top-6"
+    >
+      &times;
+    </button>
+    <h2 nbDialogTitle nbTitle>Dialog Title</h2>
+    <p nbDialogDescription>This is a description of the dialog.</p>
+  </div>
+
+  <nb-dialog-content class="px-6 py-4">
+    <p>Dialog content goes here.</p>
+  </nb-dialog-content>
+
+  <nb-dialog-actions class="px-6 py-4 flex justify-end gap-3">
+    <button nbButton tone="background" nbDialogClose>Cancel</button>
+    <button nbButton nbDialogClose>Confirm</button>
+  </nb-dialog-actions>
+</nb-dialog>
+```
+
+### Contact Us Form
+```html
+<button nbButton style="--nb-button-bg: #fff" (click)="dialog.open()">Contact Us</button>
+<nb-dialog #dialog>
+  <div class="relative bg-(--nb-field-bg) px-6 pt-7 pb-5 sm:px-10 sm:pt-9 sm:pb-6">
+    <button
+      nbIconButton
+      nbDialogClose
+      tone="background"
+      radius="md"
+      aria-label="Close dialog"
+      style="--nb-icon-button-bg: #fff"
+      class="absolute right-6 top-6 text-xl leading-none sm:right-10 sm:top-9"
+    >
+      &times;
+    </button>
+
+    <span class="inline-block border-2 border-(--nb-border) bg-[#c4a8ff] px-4 py-1.5 font-mono text-sm font-black uppercase tracking-wider text-black shadow-[3px_3px_0_0_var(--nb-shadow)]">
+      Let's Talk
+    </span>
+
+    <h2 nbDialogTitle nbTitle class="mt-4 p-0 font-mono text-3xl font-black leading-tight">
+      Send us a message
+    </h2>
+
+    <p nbDialogDescription class="mt-3 inline-block p-0 font-mono text-base font-medium text-black">
+      Fill in the form below and we'll get back to you as soon as possible.
+    </p>
+  </div>
+
+  <nb-dialog-content class="border-y-0 bg-white px-6 pb-6 pt-4 sm:px-10">
+    <form class="grid gap-5">
+      <div class="grid gap-5 sm:grid-cols-2">
+        <div class="grid min-w-0 gap-2">
+          <label nbLabel for="contact-name" class="font-mono text-base">Name</label>
+          <nb-input-group class="min-w-0">
+            <input nbInput id="contact-name" placeholder="Your name" class="h-12 font-mono" />
+          </nb-input-group>
+        </div>
+        <div class="grid min-w-0 gap-2">
+          <label nbLabel for="contact-email" class="font-mono text-base">Email</label>
+          <nb-input-group class="min-w-0">
+            <input nbInput id="contact-email" type="email" placeholder="you@company.com" class="h-12 font-mono" />
+          </nb-input-group>
+        </div>
+      </div>
+
+      <div class="grid gap-2">
+        <label nbLabel id="contact-subject-label" class="font-mono text-base">Subject</label>
+        <nb-input-group>
+          <nb-select
+            placeholder="What is this regarding?"
+            aria-labelledby="contact-subject-label"
+          >
+            <nb-select-option value="general" label="General Inquiry">
+              General Inquiry
+            </nb-select-option>
+            <nb-select-option value="project" label="Project Proposal">
+              Project Proposal
+            </nb-select-option>
+            <nb-select-option value="bug" label="Bug Report">
+              Bug Report
+            </nb-select-option>
+            <nb-select-option value="other" label="Other">
+              Other
+            </nb-select-option>
+          </nb-select>
+        </nb-input-group>
+      </div>
+
+      <div class="grid gap-2">
+        <label nbLabel for="contact-message" class="font-mono text-base">Message</label>
+        <nb-input-group>
+          <textarea nbTextarea id="contact-message" placeholder="Type your message here..." class="min-h-40 font-mono"></textarea>
+        </nb-input-group>
+      </div>
+    </form>
+  </nb-dialog-content>
+
+  <nb-dialog-actions class="flex-col items-stretch justify-between gap-4 border-t-2 border-(--nb-border) bg-white px-6 py-5 sm:flex-row sm:items-center sm:px-10">
+    <div class="flex items-center gap-3">
+      <div class="font-mono text-xs leading-tight">
+        <p class="font-bold">Your data is safe with us.</p>
+        <p>We'll never share your info.</p>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-3">
+      <button nbButton tone="background" nbDialogClose class="min-w-28 font-mono" style="--nb-button-bg: #fff">Cancel</button>
+      <button nbButton nbDialogClose class="flex min-w-36 items-center justify-center gap-2 font-mono" style="--nb-button-bg: #ffd92e; --nb-button-fg: #000;">
+        Send Message
+      </button>
+    </div>
+  </nb-dialog-actions>
+</nb-dialog>

--- a/skills/ng-brutalism/references/dialog.md
+++ b/skills/ng-brutalism/references/dialog.md
@@ -3,55 +3,32 @@
 The neo-brutalist Angular Dialog component — a brutalist modal built on the native `<dialog>` element. Compound API with SSR-safe open/close. Click the backdrop to dismiss.
 
 ## Import
+
 ```typescript
-import {
-  NbButton,
-  NbDialog,
-  NbDialogTitle,
-  NbDialogDescription,
-  NbDialogContent,
-  NbDialogActions,
-  NbDialogClose,
-  NbIconButton,
-  NbTitle,
-  NbInput,
-  NbInputGroup,
-  NbInputPrefix,
-  NbLabel,
-  NbSelect,
-  NbSelectOption,
-  NbTextarea,
-} from '@ng-brutalism/ui';
+import { NbButton, NbDialog, NbDialogTitle, NbDialogDescription, NbDialogContent, NbDialogActions, NbDialogClose, NbIconButton, NbTitle, NbInput, NbInputGroup, NbInputPrefix, NbLabel, NbSelect, NbSelectOption, NbTextarea } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Part | Description |
-|---|---|
-| `nb-dialog` | Root component. Renders the native `<dialog>` modal. Exposes `open()` and `close()` for `viewChild` access. |
-| `[nbDialogTitle]` | Directive applied to a heading element. Styles the dialog title. |
-| `[nbDialogDescription]` | Directive for muted supporting text below the title. |
-| `nb-dialog-content` | Scrollable body section with top and bottom borders. |
-| `nb-dialog-actions` | Footer section with right-aligned action buttons. |
-| `[nbDialogClose]` | Directive that closes the dialog on click. |
+
+| Part                    | Description                                                                                                 |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `nb-dialog`             | Root component. Renders the native `<dialog>` modal. Exposes `open()` and `close()` for `viewChild` access. |
+| `[nbDialogTitle]`       | Directive applied to a heading element. Styles the dialog title.                                            |
+| `[nbDialogDescription]` | Directive for muted supporting text below the title.                                                        |
+| `nb-dialog-content`     | Scrollable body section with top and bottom borders.                                                        |
+| `nb-dialog-actions`     | Footer section with right-aligned action buttons.                                                           |
+| `[nbDialogClose]`       | Directive that closes the dialog on click.                                                                  |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <button nbButton (click)="dialog.open()">Open Dialog</button>
 
 <nb-dialog #dialog>
   <div class="relative p-6">
-    <button
-      nbIconButton
-      nbDialogClose
-      tone="background"
-      radius="md"
-      aria-label="Close dialog"
-      class="absolute right-6 top-6"
-    >
-      &times;
-    </button>
+    <button nbIconButton nbDialogClose tone="background" radius="md" aria-label="Close dialog" class="absolute right-6 top-6">&times;</button>
     <h2 nbDialogTitle nbTitle>Dialog Title</h2>
     <p nbDialogDescription>This is a description of the dialog.</p>
   </div>
@@ -68,33 +45,18 @@ import {
 ```
 
 ### Contact Us Form
+
 ```html
 <button nbButton style="--nb-button-bg: #fff" (click)="dialog.open()">Contact Us</button>
 <nb-dialog #dialog>
   <div class="relative bg-(--nb-field-bg) px-6 pt-7 pb-5 sm:px-10 sm:pt-9 sm:pb-6">
-    <button
-      nbIconButton
-      nbDialogClose
-      tone="background"
-      radius="md"
-      aria-label="Close dialog"
-      style="--nb-icon-button-bg: #fff"
-      class="absolute right-6 top-6 text-xl leading-none sm:right-10 sm:top-9"
-    >
-      &times;
-    </button>
+    <button nbIconButton nbDialogClose tone="background" radius="md" aria-label="Close dialog" style="--nb-icon-button-bg: #fff" class="absolute right-6 top-6 text-xl leading-none sm:right-10 sm:top-9">&times;</button>
 
-    <span class="inline-block border-2 border-(--nb-border) bg-[#c4a8ff] px-4 py-1.5 font-mono text-sm font-black uppercase tracking-wider text-black shadow-[3px_3px_0_0_var(--nb-shadow)]">
-      Let's Talk
-    </span>
+    <span class="inline-block border-2 border-(--nb-border) bg-[#c4a8ff] px-4 py-1.5 font-mono text-sm font-black uppercase tracking-wider text-black shadow-[3px_3px_0_0_var(--nb-shadow)]"> Let's Talk </span>
 
-    <h2 nbDialogTitle nbTitle class="mt-4 p-0 font-mono text-3xl font-black leading-tight">
-      Send us a message
-    </h2>
+    <h2 nbDialogTitle nbTitle class="mt-4 p-0 font-mono text-3xl font-black leading-tight">Send us a message</h2>
 
-    <p nbDialogDescription class="mt-3 inline-block p-0 font-mono text-base font-medium text-black">
-      Fill in the form below and we'll get back to you as soon as possible.
-    </p>
+    <p nbDialogDescription class="mt-3 inline-block p-0 font-mono text-base font-medium text-black">Fill in the form below and we'll get back to you as soon as possible.</p>
   </div>
 
   <nb-dialog-content class="border-y-0 bg-white px-6 pb-6 pt-4 sm:px-10">
@@ -117,22 +79,11 @@ import {
       <div class="grid gap-2">
         <label nbLabel id="contact-subject-label" class="font-mono text-base">Subject</label>
         <nb-input-group>
-          <nb-select
-            placeholder="What is this regarding?"
-            aria-labelledby="contact-subject-label"
-          >
-            <nb-select-option value="general" label="General Inquiry">
-              General Inquiry
-            </nb-select-option>
-            <nb-select-option value="project" label="Project Proposal">
-              Project Proposal
-            </nb-select-option>
-            <nb-select-option value="bug" label="Bug Report">
-              Bug Report
-            </nb-select-option>
-            <nb-select-option value="other" label="Other">
-              Other
-            </nb-select-option>
+          <nb-select placeholder="What is this regarding?" aria-labelledby="contact-subject-label">
+            <nb-select-option value="general" label="General Inquiry"> General Inquiry </nb-select-option>
+            <nb-select-option value="project" label="Project Proposal"> Project Proposal </nb-select-option>
+            <nb-select-option value="bug" label="Bug Report"> Bug Report </nb-select-option>
+            <nb-select-option value="other" label="Other"> Other </nb-select-option>
           </nb-select>
         </nb-input-group>
       </div>
@@ -156,9 +107,8 @@ import {
 
     <div class="flex items-center gap-3">
       <button nbButton tone="background" nbDialogClose class="min-w-28 font-mono" style="--nb-button-bg: #fff">Cancel</button>
-      <button nbButton nbDialogClose class="flex min-w-36 items-center justify-center gap-2 font-mono" style="--nb-button-bg: #ffd92e; --nb-button-fg: #000;">
-        Send Message
-      </button>
+      <button nbButton nbDialogClose class="flex min-w-36 items-center justify-center gap-2 font-mono" style="--nb-button-bg: #ffd92e; --nb-button-fg: #000;">Send Message</button>
     </div>
   </nb-dialog-actions>
 </nb-dialog>
+```

--- a/skills/ng-brutalism/references/display.md
+++ b/skills/ng-brutalism/references/display.md
@@ -3,24 +3,28 @@
 A directive for mega-sized display text. Apply it to **any element** — a heading, a `span`, a stat — to get ultra-bold, tight-leading display typography. It's purely presentational, so keep your semantics correct and let the directive handle the look.
 
 ## Import
+
 ```typescript
 import { NbDisplay } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `size` | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | Controls font size via `--nb-display-size`. |
-| `underline` | `'none' \| 'bar' \| 'wave'` | `'none'` | Draws a built-in accent underline beneath the text. Style it with the `--nb-underline-*` tokens. |
+
+| Attribute   | Type                           | Default  | Description                                                                                      |
+| ----------- | ------------------------------ | -------- | ------------------------------------------------------------------------------------------------ |
+| `size`      | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'`   | Controls font size via `--nb-display-size`.                                                      |
+| `underline` | `'none' \| 'bar' \| 'wave'`    | `'none'` | Draws a built-in accent underline beneath the text. Style it with the `--nb-underline-*` tokens. |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <h2 nbDisplay class="uppercase">SENIOR ANGULAR ENGINEER</h2>
 ```
 
 ### Sizes
+
 ```html
 <h2 nbDisplay size="sm" class="uppercase">PRO PLAN</h2>
 <h2 nbDisplay size="md" class="uppercase">INDIE CUP</h2>
@@ -29,31 +33,23 @@ import { NbDisplay } from '@ng-brutalism/ui';
 ```
 
 ### Custom Size
+
 ```html
-<h2 nbDisplay class="uppercase" style="--nb-display-size: 2.25rem">
-  $29/mo
-</h2>
+<h2 nbDisplay class="uppercase" style="--nb-display-size: 2.25rem">$29/mo</h2>
 ```
 
 ### Any Element
+
 ```html
-<span nbDisplay size="lg">$2.4M</span>
-<span nbDisplay size="lg" class="uppercase">24/7</span>
+<span nbDisplay size="lg">$2.4M</span> <span nbDisplay size="lg" class="uppercase">24/7</span>
 ```
 
 ### Underline
+
 ```html
 <h2 nbDisplay size="lg" underline="bar" class="uppercase">SHIP IT</h2>
 <h2 nbDisplay size="lg" underline="wave" class="uppercase">STAY SHARP</h2>
 
 <!-- Recolor / resize with tokens -->
-<h2
-  nbDisplay
-  size="lg"
-  underline="bar"
-  class="uppercase"
-  style="--nb-underline-color: var(--nb-mint); --nb-underline-width: 100%"
->
-  FULL WIDTH
-</h2>
+<h2 nbDisplay size="lg" underline="bar" class="uppercase" style="--nb-underline-color: var(--nb-mint); --nb-underline-width: 100%">FULL WIDTH</h2>
 ```

--- a/skills/ng-brutalism/references/display.md
+++ b/skills/ng-brutalism/references/display.md
@@ -1,0 +1,59 @@
+# Display
+
+A directive for mega-sized display text. Apply it to **any element** — a heading, a `span`, a stat — to get ultra-bold, tight-leading display typography. It's purely presentational, so keep your semantics correct and let the directive handle the look.
+
+## Import
+```typescript
+import { NbDisplay } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `size` | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | Controls font size via `--nb-display-size`. |
+| `underline` | `'none' \| 'bar' \| 'wave'` | `'none'` | Draws a built-in accent underline beneath the text. Style it with the `--nb-underline-*` tokens. |
+
+## Usage Examples
+
+### Default
+```html
+<h2 nbDisplay class="uppercase">SENIOR ANGULAR ENGINEER</h2>
+```
+
+### Sizes
+```html
+<h2 nbDisplay size="sm" class="uppercase">PRO PLAN</h2>
+<h2 nbDisplay size="md" class="uppercase">INDIE CUP</h2>
+<h2 nbDisplay size="lg" class="uppercase">NORA CHEN</h2>
+<h2 nbDisplay size="xl" class="uppercase">GO</h2>
+```
+
+### Custom Size
+```html
+<h2 nbDisplay class="uppercase" style="--nb-display-size: 2.25rem">
+  $29/mo
+</h2>
+```
+
+### Any Element
+```html
+<span nbDisplay size="lg">$2.4M</span>
+<span nbDisplay size="lg" class="uppercase">24/7</span>
+```
+
+### Underline
+```html
+<h2 nbDisplay size="lg" underline="bar" class="uppercase">SHIP IT</h2>
+<h2 nbDisplay size="lg" underline="wave" class="uppercase">STAY SHARP</h2>
+
+<!-- Recolor / resize with tokens -->
+<h2
+  nbDisplay
+  size="lg"
+  underline="bar"
+  class="uppercase"
+  style="--nb-underline-color: var(--nb-mint); --nb-underline-width: 100%"
+>
+  FULL WIDTH
+</h2>
+```

--- a/skills/ng-brutalism/references/halftone.md
+++ b/skills/ng-brutalism/references/halftone.md
@@ -3,30 +3,30 @@
 A decorative dot-grid component that anchors to card corners via absolute positioning or renders as a clean rectangular strip. The classic halftone pattern borrowed from print design adds depth and texture to brutalist cards without cluttering the layout.
 
 ## Import
+
 ```typescript
 import { NbHalftone } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `shape` | `'square' \| 'circle' \| 'rectangle'` | `'square'` | Visual shape. Rectangle renders a CSS background strip. |
-| `color` | `string` | `var(--nb-border)` | Dot fill color (any CSS color value). |
-| `rows` | `number` | `7 / 3 rectangle` | Number of dot rows. |
-| `columns` | `number` | `7 / 13 rectangle` | Number of dot columns. |
-| `size` | `number` | `6 / 8 rectangle` | Dot diameter in px. |
-| `gap` | `number` | `5 / rectangle rhythm` | Gap between dots in px. Rectangle strips use this as both axes unless gapX or gapY is set. |
-| `gapX` | `number` | `28 rectangle` | Horizontal rectangle dot rhythm in px. |
-| `gapY` | `number` | `27 rectangle` | Vertical rectangle dot rhythm in px. |
+
+| Attribute | Type                                  | Default                | Description                                                                                |
+| --------- | ------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------ |
+| `shape`   | `'square' \| 'circle' \| 'rectangle'` | `'square'`             | Visual shape. Rectangle renders a CSS background strip.                                    |
+| `color`   | `string`                              | `var(--nb-border)`     | Dot fill color (any CSS color value).                                                      |
+| `rows`    | `number`                              | `7 / 3 rectangle`      | Number of dot rows.                                                                        |
+| `columns` | `number`                              | `7 / 13 rectangle`     | Number of dot columns.                                                                     |
+| `size`    | `number`                              | `6 / 8 rectangle`      | Dot diameter in px.                                                                        |
+| `gap`     | `number`                              | `5 / rectangle rhythm` | Gap between dots in px. Rectangle strips use this as both axes unless gapX or gapY is set. |
+| `gapX`    | `number`                              | `28 rectangle`         | Horizontal rectangle dot rhythm in px.                                                     |
+| `gapY`    | `number`                              | `27 rectangle`         | Vertical rectangle dot rhythm in px.                                                       |
 
 ## Usage Examples
 
 ### Default
+
 ```html
-<div
-  class="relative overflow-hidden border-2 border-(--nb-border) bg-nb-paper p-8 shadow-[5px_5px_0_0_var(--nb-shadow)]"
-  style="min-height: 140px;"
->
+<div class="relative overflow-hidden border-2 border-(--nb-border) bg-nb-paper p-8 shadow-[5px_5px_0_0_var(--nb-shadow)]" style="min-height: 140px;">
   <div nbHalftone class="absolute bottom-0 right-0"></div>
   <p class="font-bold text-lg">Card with halftone</p>
   <p class="font-medium text-sm mt-1">Dot grid anchors to the bottom-right corner.</p>
@@ -34,11 +34,9 @@ import { NbHalftone } from '@ng-brutalism/ui';
 ```
 
 ### Custom Color & Positioning
+
 ```html
-<div
-  class="relative overflow-hidden border-2 border-(--nb-border) bg-nb-paper p-8 shadow-[5px_5px_0_0_var(--nb-shadow)]"
-  style="min-height: 140px;"
->
+<div class="relative overflow-hidden border-2 border-(--nb-border) bg-nb-paper p-8 shadow-[5px_5px_0_0_var(--nb-shadow)]" style="min-height: 140px;">
   <div nbHalftone color="#ff90e8" class="absolute top-0 right-0"></div>
   <div nbHalftone color="#8ae9ff" class="absolute bottom-0 left-0"></div>
   <p class="font-bold">Custom dot colors</p>
@@ -46,33 +44,19 @@ import { NbHalftone } from '@ng-brutalism/ui';
 ```
 
 ### Rectangle
+
 ```html
 <div class="relative overflow-hidden border-2 border-(--nb-border) bg-nb-paper p-8 shadow-[5px_5px_0_0_var(--nb-shadow)]">
-  <div
-    nbHalftone
-    shape="rectangle"
-    [rows]="3"
-    [columns]="13"
-    class="mb-5"
-  ></div>
+  <div nbHalftone shape="rectangle" [rows]="3" [columns]="13" class="mb-5"></div>
   <p class="font-bold text-lg">Graphic strip accent</p>
-  <p class="font-medium text-sm mt-1">
-    A rectangular dot matrix with a predictable 3 by 13 count.
-  </p>
+  <p class="font-medium text-sm mt-1">A rectangular dot matrix with a predictable 3 by 13 count.</p>
 </div>
 ```
 
 ### Custom Rectangle
+
 ```html
 <div class="relative overflow-hidden border-2 border-(--nb-border) bg-nb-paper p-8 shadow-[5px_5px_0_0_var(--nb-shadow)]">
-  <div
-    nbHalftone
-    shape="rectangle"
-    [rows]="3"
-    [columns]="13"
-    [size]="8"
-    [gapX]="28"
-    [gapY]="27"
-  ></div>
+  <div nbHalftone shape="rectangle" [rows]="3" [columns]="13" [size]="8" [gapX]="28" [gapY]="27"></div>
 </div>
 ```

--- a/skills/ng-brutalism/references/halftone.md
+++ b/skills/ng-brutalism/references/halftone.md
@@ -1,0 +1,78 @@
+# Halftone
+
+A decorative dot-grid component that anchors to card corners via absolute positioning or renders as a clean rectangular strip. The classic halftone pattern borrowed from print design adds depth and texture to brutalist cards without cluttering the layout.
+
+## Import
+```typescript
+import { NbHalftone } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `shape` | `'square' \| 'circle' \| 'rectangle'` | `'square'` | Visual shape. Rectangle renders a CSS background strip. |
+| `color` | `string` | `var(--nb-border)` | Dot fill color (any CSS color value). |
+| `rows` | `number` | `7 / 3 rectangle` | Number of dot rows. |
+| `columns` | `number` | `7 / 13 rectangle` | Number of dot columns. |
+| `size` | `number` | `6 / 8 rectangle` | Dot diameter in px. |
+| `gap` | `number` | `5 / rectangle rhythm` | Gap between dots in px. Rectangle strips use this as both axes unless gapX or gapY is set. |
+| `gapX` | `number` | `28 rectangle` | Horizontal rectangle dot rhythm in px. |
+| `gapY` | `number` | `27 rectangle` | Vertical rectangle dot rhythm in px. |
+
+## Usage Examples
+
+### Default
+```html
+<div
+  class="relative overflow-hidden border-2 border-(--nb-border) bg-nb-paper p-8 shadow-[5px_5px_0_0_var(--nb-shadow)]"
+  style="min-height: 140px;"
+>
+  <div nbHalftone class="absolute bottom-0 right-0"></div>
+  <p class="font-bold text-lg">Card with halftone</p>
+  <p class="font-medium text-sm mt-1">Dot grid anchors to the bottom-right corner.</p>
+</div>
+```
+
+### Custom Color & Positioning
+```html
+<div
+  class="relative overflow-hidden border-2 border-(--nb-border) bg-nb-paper p-8 shadow-[5px_5px_0_0_var(--nb-shadow)]"
+  style="min-height: 140px;"
+>
+  <div nbHalftone color="#ff90e8" class="absolute top-0 right-0"></div>
+  <div nbHalftone color="#8ae9ff" class="absolute bottom-0 left-0"></div>
+  <p class="font-bold">Custom dot colors</p>
+</div>
+```
+
+### Rectangle
+```html
+<div class="relative overflow-hidden border-2 border-(--nb-border) bg-nb-paper p-8 shadow-[5px_5px_0_0_var(--nb-shadow)]">
+  <div
+    nbHalftone
+    shape="rectangle"
+    [rows]="3"
+    [columns]="13"
+    class="mb-5"
+  ></div>
+  <p class="font-bold text-lg">Graphic strip accent</p>
+  <p class="font-medium text-sm mt-1">
+    A rectangular dot matrix with a predictable 3 by 13 count.
+  </p>
+</div>
+```
+
+### Custom Rectangle
+```html
+<div class="relative overflow-hidden border-2 border-(--nb-border) bg-nb-paper p-8 shadow-[5px_5px_0_0_var(--nb-shadow)]">
+  <div
+    nbHalftone
+    shape="rectangle"
+    [rows]="3"
+    [columns]="13"
+    [size]="8"
+    [gapX]="28"
+    [gapY]="27"
+  ></div>
+</div>
+```

--- a/skills/ng-brutalism/references/icon-button.md
+++ b/skills/ng-brutalism/references/icon-button.md
@@ -1,0 +1,115 @@
+# IconButton
+
+A `<button>` for icon-only actions. Supports square and circle shapes, 4 sizes, tunable corner radius, and the shared `tone` color palette. Pass an `icon` URL to render it internally, or project your own `<svg>` via `ng-content`.
+
+## Import
+```typescript
+import { NbIconButton } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `shape` | `'square' \| 'circle'` | `'square'` | Button border radius. |
+| `size` | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | Touch target size (32/40/48/56px). |
+| `tone` | `NbToneToken` | `'default'` | Shared color tone — writes background, foreground, and border color. |
+| `radius` | `NbRadius` | `'none'` | Corner radius for square buttons. Ignored when shape is 'circle'. |
+| `shadow` | `NbShadow` | `'default'` | Brutalist drop shadow depth. |
+| `border` | `NbBorderStrength` | `'default'` | Outline strength — writes the border width. |
+| `icon` | `string` | — | SVG/image URL rendered internally via nbIcon (mask mode, sized to the button). Omit to project your own icon. |
+
+## Usage Examples
+
+### Default
+```html
+<button nbIconButton aria-label="Like">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+  </svg>
+</button>
+
+<button nbIconButton shape="circle" aria-label="Like">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+  </svg>
+</button>
+
+<button nbIconButton tone="danger" aria-label="Delete">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <polyline points="3 6 5 6 21 6"/>
+    <path d="M19 6l-1 14H6L5 6"/>
+    <path d="M10 11v6"/>
+    <path d="M14 11v6"/>
+    <path d="M9 6V4h6v2"/>
+  </svg>
+</button>
+```
+
+### Shapes
+```html
+<button nbIconButton aria-label="Square action">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+  </svg>
+</button>
+
+<button nbIconButton shape="circle" aria-label="Circle action">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+  </svg>
+</button>
+```
+
+### Sizes
+```html
+<button nbIconButton size="sm" aria-label="Small">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+  </svg>
+</button>
+
+<button nbIconButton aria-label="Default">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+  </svg>
+</button>
+
+<button nbIconButton size="lg" aria-label="Large">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+  </svg>
+</button>
+```
+
+### Tones
+```html
+<button nbIconButton aria-label="Default">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+  </svg>
+</button>
+
+<button nbIconButton tone="primary" aria-label="Primary">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+  </svg>
+</button>
+
+<button nbIconButton tone="accent" aria-label="Accent">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+  </svg>
+</button>
+
+<button nbIconButton tone="danger" aria-label="Danger">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+  </svg>
+</button>
+
+<button nbIconButton tone="success" aria-label="Success">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+  </svg>
+</button>
+```

--- a/skills/ng-brutalism/references/icon-button.md
+++ b/skills/ng-brutalism/references/icon-button.md
@@ -3,113 +3,129 @@
 A `<button>` for icon-only actions. Supports square and circle shapes, 4 sizes, tunable corner radius, and the shared `tone` color palette. Pass an `icon` URL to render it internally, or project your own `<svg>` via `ng-content`.
 
 ## Import
+
 ```typescript
 import { NbIconButton } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `shape` | `'square' \| 'circle'` | `'square'` | Button border radius. |
-| `size` | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | Touch target size (32/40/48/56px). |
-| `tone` | `NbToneToken` | `'default'` | Shared color tone — writes background, foreground, and border color. |
-| `radius` | `NbRadius` | `'none'` | Corner radius for square buttons. Ignored when shape is 'circle'. |
-| `shadow` | `NbShadow` | `'default'` | Brutalist drop shadow depth. |
-| `border` | `NbBorderStrength` | `'default'` | Outline strength — writes the border width. |
-| `icon` | `string` | — | SVG/image URL rendered internally via nbIcon (mask mode, sized to the button). Omit to project your own icon. |
+
+| Attribute | Type                           | Default     | Description                                                                                                   |
+| --------- | ------------------------------ | ----------- | ------------------------------------------------------------------------------------------------------------- |
+| `shape`   | `'square' \| 'circle'`         | `'square'`  | Button border radius.                                                                                         |
+| `size`    | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'`      | Touch target size (32/40/48/56px).                                                                            |
+| `tone`    | `NbToneToken`                  | `'default'` | Shared color tone — writes background, foreground, and border color.                                          |
+| `radius`  | `NbRadius`                     | `'none'`    | Corner radius for square buttons. Ignored when shape is 'circle'.                                             |
+| `shadow`  | `NbShadow`                     | `'default'` | Brutalist drop shadow depth.                                                                                  |
+| `border`  | `NbBorderStrength`             | `'default'` | Outline strength — writes the border width.                                                                   |
+| `icon`    | `string`                       | —           | SVG/image URL rendered internally via nbIcon (mask mode, sized to the button). Omit to project your own icon. |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <button nbIconButton aria-label="Like">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
   </svg>
 </button>
 
 <button nbIconButton shape="circle" aria-label="Like">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
   </svg>
 </button>
 
 <button nbIconButton tone="danger" aria-label="Delete">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-    <polyline points="3 6 5 6 21 6"/>
-    <path d="M19 6l-1 14H6L5 6"/>
-    <path d="M10 11v6"/>
-    <path d="M14 11v6"/>
-    <path d="M9 6V4h6v2"/>
+    <polyline points="3 6 5 6 21 6" />
+    <path d="M19 6l-1 14H6L5 6" />
+    <path d="M10 11v6" />
+    <path d="M14 11v6" />
+    <path d="M9 6V4h6v2" />
   </svg>
 </button>
 ```
 
 ### Shapes
+
 ```html
 <button nbIconButton aria-label="Square action">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
   </svg>
 </button>
 
 <button nbIconButton shape="circle" aria-label="Circle action">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
   </svg>
 </button>
 ```
 
 ### Sizes
+
 ```html
 <button nbIconButton size="sm" aria-label="Small">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
   </svg>
 </button>
 
 <button nbIconButton aria-label="Default">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
   </svg>
 </button>
 
 <button nbIconButton size="lg" aria-label="Large">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
   </svg>
 </button>
 ```
 
 ### Tones
+
 ```html
 <button nbIconButton aria-label="Default">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-    <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+    <circle cx="12" cy="12" r="10" />
+    <line x1="12" y1="8" x2="12" y2="12" />
+    <line x1="12" y1="16" x2="12.01" y2="16" />
   </svg>
 </button>
 
 <button nbIconButton tone="primary" aria-label="Primary">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-    <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+    <circle cx="12" cy="12" r="10" />
+    <line x1="12" y1="8" x2="12" y2="12" />
+    <line x1="12" y1="16" x2="12.01" y2="16" />
   </svg>
 </button>
 
 <button nbIconButton tone="accent" aria-label="Accent">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-    <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+    <circle cx="12" cy="12" r="10" />
+    <line x1="12" y1="8" x2="12" y2="12" />
+    <line x1="12" y1="16" x2="12.01" y2="16" />
   </svg>
 </button>
 
 <button nbIconButton tone="danger" aria-label="Danger">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-    <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+    <circle cx="12" cy="12" r="10" />
+    <line x1="12" y1="8" x2="12" y2="12" />
+    <line x1="12" y1="16" x2="12.01" y2="16" />
   </svg>
 </button>
 
 <button nbIconButton tone="success" aria-label="Success">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-    <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+    <circle cx="12" cy="12" r="10" />
+    <line x1="12" y1="8" x2="12" y2="12" />
+    <line x1="12" y1="16" x2="12.01" y2="16" />
   </svg>
 </button>
 ```

--- a/skills/ng-brutalism/references/icon.md
+++ b/skills/ng-brutalism/references/icon.md
@@ -3,23 +3,26 @@
 `nbIcon` is an attribute directive that renders any SVG asset as a sized, colored, accessible icon. Mask mode (default) paints monochrome SVGs with the current color. Image mode preserves original colors for illustrated assets. Composable with chips, buttons, and any other primitive.
 
 ## Import
+
 ```typescript
 import { NbIcon } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `src` | `string` | required | Path to a trusted local SVG or image asset. Do not pass unsanitized user-generated URLs. |
-| `size` | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | Icon size (0.75 rem – 2 rem). |
-| `tone` | `'current' \| 'default' \| 'muted' \| 'inverse' \| 'primary' \| 'secondary' \| 'accent' \| 'danger' \| 'success' \| 'warning'` | `'current'` | Color tone. `current` inherits the parent CSS color. Only applies in mask mode. |
-| `mode` | `'mask' \| 'image'` | `'mask'` | Rendering mode. `mask` paints the SVG with the tone color. `image` preserves original asset colors. |
-| `decorative` | `boolean` | `false` | Marks the icon as purely decorative (`aria-hidden="true"`). Use when the icon adds no information beyond adjacent text. |
-| `label` | `string \| null` | `null` | Accessible label for meaningful icons. Sets `role="img"` and `aria-label`. Ignored when `decorative` is true. |
+
+| Attribute    | Type                                                                                                                           | Default     | Description                                                                                                             |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------ | ----------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `src`        | `string`                                                                                                                       | required    | Path to a trusted local SVG or image asset. Do not pass unsanitized user-generated URLs.                                |
+| `size`       | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'`                                                                                         | `'md'`      | Icon size (0.75 rem – 2 rem).                                                                                           |
+| `tone`       | `'current' \| 'default' \| 'muted' \| 'inverse' \| 'primary' \| 'secondary' \| 'accent' \| 'danger' \| 'success' \| 'warning'` | `'current'` | Color tone. `current` inherits the parent CSS color. Only applies in mask mode.                                         |
+| `mode`       | `'mask' \| 'image'`                                                                                                            | `'mask'`    | Rendering mode. `mask` paints the SVG with the tone color. `image` preserves original asset colors.                     |
+| `decorative` | `boolean`                                                                                                                      | `false`     | Marks the icon as purely decorative (`aria-hidden="true"`). Use when the icon adds no information beyond adjacent text. |
+| `label`      | `string \| null`                                                                                                               | `null`      | Accessible label for meaningful icons. Sets `role="img"` and `aria-label`. Ignored when `decorative` is true.           |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <!-- Decorative icon (no meaning beyond adjacent text) -->
 <span nbIcon src="/icons/plane.svg" size="sm" decorative></span>
@@ -29,6 +32,7 @@ import { NbIcon } from '@ng-brutalism/ui';
 ```
 
 ### Sizes
+
 ```html
 <span nbIcon src="/icons/plane.svg" size="xs" decorative></span>
 <span nbIcon src="/icons/plane.svg" size="sm" decorative></span>
@@ -38,6 +42,7 @@ import { NbIcon } from '@ng-brutalism/ui';
 ```
 
 ### Tones
+
 ```html
 <span nbIcon src="/icons/star.svg" size="md" tone="current" decorative></span>
 <span nbIcon src="/icons/star.svg" size="md" tone="default" decorative></span>
@@ -52,6 +57,7 @@ import { NbIcon } from '@ng-brutalism/ui';
 ```
 
 ### Modes
+
 ```html
 <!-- mask: paints the SVG with the tone color -->
 <span nbIcon src="/icons/plane.svg" size="xl" mode="mask" tone="primary" decorative></span>
@@ -61,6 +67,7 @@ import { NbIcon } from '@ng-brutalism/ui';
 ```
 
 ### Accessibility
+
 ```html
 <!-- Decorative — icon is supplementary to adjacent text -->
 <span nbIcon src="/icons/star.svg" size="lg" tone="warning" decorative></span>
@@ -70,6 +77,7 @@ import { NbIcon } from '@ng-brutalism/ui';
 ```
 
 ### Composition
+
 ```html
 <!-- Icons inside chips -->
 <div nbChipGroup>

--- a/skills/ng-brutalism/references/icon.md
+++ b/skills/ng-brutalism/references/icon.md
@@ -1,0 +1,97 @@
+# Icon
+
+`nbIcon` is an attribute directive that renders any SVG asset as a sized, colored, accessible icon. Mask mode (default) paints monochrome SVGs with the current color. Image mode preserves original colors for illustrated assets. Composable with chips, buttons, and any other primitive.
+
+## Import
+```typescript
+import { NbIcon } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `src` | `string` | required | Path to a trusted local SVG or image asset. Do not pass unsanitized user-generated URLs. |
+| `size` | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | Icon size (0.75 rem – 2 rem). |
+| `tone` | `'current' \| 'default' \| 'muted' \| 'inverse' \| 'primary' \| 'secondary' \| 'accent' \| 'danger' \| 'success' \| 'warning'` | `'current'` | Color tone. `current` inherits the parent CSS color. Only applies in mask mode. |
+| `mode` | `'mask' \| 'image'` | `'mask'` | Rendering mode. `mask` paints the SVG with the tone color. `image` preserves original asset colors. |
+| `decorative` | `boolean` | `false` | Marks the icon as purely decorative (`aria-hidden="true"`). Use when the icon adds no information beyond adjacent text. |
+| `label` | `string \| null` | `null` | Accessible label for meaningful icons. Sets `role="img"` and `aria-label`. Ignored when `decorative` is true. |
+
+## Usage Examples
+
+### Default
+```html
+<!-- Decorative icon (no meaning beyond adjacent text) -->
+<span nbIcon src="/icons/plane.svg" size="sm" decorative></span>
+
+<!-- Meaningful standalone icon -->
+<span nbIcon src="/icons/warning.svg" size="md" tone="danger" label="Warning"></span>
+```
+
+### Sizes
+```html
+<span nbIcon src="/icons/plane.svg" size="xs" decorative></span>
+<span nbIcon src="/icons/plane.svg" size="sm" decorative></span>
+<span nbIcon src="/icons/plane.svg" size="md" decorative></span>
+<span nbIcon src="/icons/plane.svg" size="lg" decorative></span>
+<span nbIcon src="/icons/plane.svg" size="xl" decorative></span>
+```
+
+### Tones
+```html
+<span nbIcon src="/icons/star.svg" size="md" tone="current" decorative></span>
+<span nbIcon src="/icons/star.svg" size="md" tone="default" decorative></span>
+<span nbIcon src="/icons/star.svg" size="md" tone="muted" decorative></span>
+<span nbIcon src="/icons/star.svg" size="md" tone="inverse" decorative></span>
+<span nbIcon src="/icons/star.svg" size="md" tone="primary" decorative></span>
+<span nbIcon src="/icons/star.svg" size="md" tone="secondary" decorative></span>
+<span nbIcon src="/icons/star.svg" size="md" tone="accent" decorative></span>
+<span nbIcon src="/icons/star.svg" size="md" tone="danger" decorative></span>
+<span nbIcon src="/icons/star.svg" size="md" tone="success" decorative></span>
+<span nbIcon src="/icons/star.svg" size="md" tone="warning" decorative></span>
+```
+
+### Modes
+```html
+<!-- mask: paints the SVG with the tone color -->
+<span nbIcon src="/icons/plane.svg" size="xl" mode="mask" tone="primary" decorative></span>
+
+<!-- image: preserves original asset colors -->
+<span nbIcon src="/icons/illustrated-plane.png" size="xl" mode="image" decorative></span>
+```
+
+### Accessibility
+```html
+<!-- Decorative — icon is supplementary to adjacent text -->
+<span nbIcon src="/icons/star.svg" size="lg" tone="warning" decorative></span>
+
+<!-- Meaningful — icon stands alone and must be labelled -->
+<span nbIcon src="/icons/star.svg" size="lg" tone="warning" label="Top rated"></span>
+```
+
+### Composition
+```html
+<!-- Icons inside chips -->
+<div nbChipGroup>
+  <span nbChip tone="mint">
+    <span nbIcon src="/icons/plane.svg" size="sm" decorative></span>
+    Flight included
+  </span>
+  <span nbChip tone="lavender">
+    <span nbIcon src="/icons/hotel.svg" size="sm" decorative></span>
+    Hotel
+  </span>
+  <span nbChip tone="pink">
+    <span nbIcon src="/icons/star.svg" size="sm" decorative></span>
+    Top pick
+  </span>
+</div>
+
+<!-- Icon inside button trailing slot -->
+<button nbButton>
+  Book Trip
+  <span nbButtonTrailingIcon class="...">
+    <span nbIcon src="/icons/arrow-right.svg" size="sm" tone="current" decorative></span>
+  </span>
+</button>
+```

--- a/skills/ng-brutalism/references/image-card.md
+++ b/skills/ng-brutalism/references/image-card.md
@@ -1,0 +1,58 @@
+# Image Card
+
+The neo-brutalist Angular Image Card component. A media card with thick borders and offset shadow, optimized for displaying images with captions.
+
+## Import
+```typescript
+import { NbImageCard, NbImageCardCaption } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `image` | `string` | required | URL of the image to render. |
+| `alt` | `string` | required | Alternative text for the image. |
+
+### Subcomponents
+| Selector | Description |
+|---|---|
+| `nb-image-card-caption` | Projected caption region rendered below the image. |
+
+## Usage Examples
+
+### Default
+```html
+<nb-image-card [image]="imageUrl" alt="A descriptive alt text">
+  <nb-image-card-caption>
+    Image caption
+  </nb-image-card-caption>
+</nb-image-card>
+```
+
+### With Custom Title Style
+```html
+<nb-image-card
+  class="w-full max-w-sm"
+  [image]="imageUrl"
+  alt="Animated Angular mascot for Ng Brutalism"
+>
+  <nb-image-card-caption>
+    <span
+      nbTitle
+      class="inline-block font-mono text-2xl font-black leading-tight text-[#dd0031]"
+      style="--nb-title-wave-color: #f4c430; --nb-title-wave-width: 10rem; --nb-title-wave-height: 0.5rem;"
+    >
+      Angular mascot
+    </span>
+  </nb-image-card-caption>
+</nb-image-card>
+```
+
+### Image Only
+```html
+<nb-image-card
+  class="w-full max-w-sm"
+  [image]="imageUrl"
+  alt="Animated Angular mascot for Ng Brutalism"
+/>
+```

--- a/skills/ng-brutalism/references/image-card.md
+++ b/skills/ng-brutalism/references/image-card.md
@@ -3,56 +3,46 @@
 The neo-brutalist Angular Image Card component. A media card with thick borders and offset shadow, optimized for displaying images with captions.
 
 ## Import
+
 ```typescript
 import { NbImageCard, NbImageCardCaption } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `image` | `string` | required | URL of the image to render. |
-| `alt` | `string` | required | Alternative text for the image. |
+
+| Attribute | Type     | Default  | Description                     |
+| --------- | -------- | -------- | ------------------------------- |
+| `image`   | `string` | required | URL of the image to render.     |
+| `alt`     | `string` | required | Alternative text for the image. |
 
 ### Subcomponents
-| Selector | Description |
-|---|---|
+
+| Selector                | Description                                        |
+| ----------------------- | -------------------------------------------------- |
 | `nb-image-card-caption` | Projected caption region rendered below the image. |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <nb-image-card [image]="imageUrl" alt="A descriptive alt text">
-  <nb-image-card-caption>
-    Image caption
-  </nb-image-card-caption>
+  <nb-image-card-caption> Image caption </nb-image-card-caption>
 </nb-image-card>
 ```
 
 ### With Custom Title Style
+
 ```html
-<nb-image-card
-  class="w-full max-w-sm"
-  [image]="imageUrl"
-  alt="Animated Angular mascot for Ng Brutalism"
->
+<nb-image-card class="w-full max-w-sm" [image]="imageUrl" alt="Animated Angular mascot for Ng Brutalism">
   <nb-image-card-caption>
-    <span
-      nbTitle
-      class="inline-block font-mono text-2xl font-black leading-tight text-[#dd0031]"
-      style="--nb-title-wave-color: #f4c430; --nb-title-wave-width: 10rem; --nb-title-wave-height: 0.5rem;"
-    >
-      Angular mascot
-    </span>
+    <span nbTitle class="inline-block font-mono text-2xl font-black leading-tight text-[#dd0031]" style="--nb-title-wave-color: #f4c430; --nb-title-wave-width: 10rem; --nb-title-wave-height: 0.5rem;"> Angular mascot </span>
   </nb-image-card-caption>
 </nb-image-card>
 ```
 
 ### Image Only
+
 ```html
-<nb-image-card
-  class="w-full max-w-sm"
-  [image]="imageUrl"
-  alt="Animated Angular mascot for Ng Brutalism"
-/>
+<nb-image-card class="w-full max-w-sm" [image]="imageUrl" alt="Animated Angular mascot for Ng Brutalism" />
 ```

--- a/skills/ng-brutalism/references/input-group.md
+++ b/skills/ng-brutalism/references/input-group.md
@@ -1,0 +1,61 @@
+# Input Group
+
+Combines inputs or textareas with bordered prefix and suffix addons, creating one continuous brutalist control.
+
+## Import
+```typescript
+import { NbInput, NbInputGroup, NbInputPrefix, NbInputSuffix } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Selector | Attribute | Type | Default | Description |
+|---|---|---|---|---|
+| `nb-input-group` | — | — | — | Container for input group elements. |
+| `[nbInputPrefix]` | `align` | `'center' \| 'stretch'` | `'center'` | Align configuration for prefix addon. |
+| `[nbInputSuffix]` | `align` | `'center' \| 'stretch'` | `'center'` | Align configuration for suffix addon. |
+
+## Usage Examples
+
+### Default
+```html
+<nb-input-group class="max-w-80">
+  <span nbInputPrefix>@</span>
+  <input nbInput placeholder="username" />
+</nb-input-group>
+```
+
+### Prefix and Suffix
+```html
+<nb-input-group class="max-w-96">
+  <span nbInputPrefix>$</span>
+  <input nbInput type="number" placeholder="Amount" />
+  <span nbInputSuffix>USD</span>
+</nb-input-group>
+```
+
+### With Label
+```html
+<div class="grid w-full max-w-96 gap-2">
+  <label nbLabel for="profile-url">Profile URL</label>
+  <nb-input-group>
+    <span nbInputPrefix class="text-[0.8rem]">https</span>
+    <input nbInput id="profile-url" placeholder="example.com" />
+  </nb-input-group>
+</div>
+```
+
+### Textarea
+```html
+<nb-input-group class="max-w-96">
+  <span nbInputPrefix align="stretch">TXT</span>
+  <textarea nbTextarea placeholder="Write a note..." rows="4"></textarea>
+</nb-input-group>
+```
+
+### Disabled
+```html
+<nb-input-group class="max-w-80">
+  <span nbInputPrefix>@</span>
+  <input nbInput placeholder="username" disabled />
+</nb-input-group>
+```

--- a/skills/ng-brutalism/references/input-group.md
+++ b/skills/ng-brutalism/references/input-group.md
@@ -3,20 +3,23 @@
 Combines inputs or textareas with bordered prefix and suffix addons, creating one continuous brutalist control.
 
 ## Import
+
 ```typescript
 import { NbInput, NbInputGroup, NbInputPrefix, NbInputSuffix } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Selector | Attribute | Type | Default | Description |
-|---|---|---|---|---|
-| `nb-input-group` | — | — | — | Container for input group elements. |
-| `[nbInputPrefix]` | `align` | `'center' \| 'stretch'` | `'center'` | Align configuration for prefix addon. |
-| `[nbInputSuffix]` | `align` | `'center' \| 'stretch'` | `'center'` | Align configuration for suffix addon. |
+
+| Selector          | Attribute | Type                    | Default    | Description                           |
+| ----------------- | --------- | ----------------------- | ---------- | ------------------------------------- |
+| `nb-input-group`  | —         | —                       | —          | Container for input group elements.   |
+| `[nbInputPrefix]` | `align`   | `'center' \| 'stretch'` | `'center'` | Align configuration for prefix addon. |
+| `[nbInputSuffix]` | `align`   | `'center' \| 'stretch'` | `'center'` | Align configuration for suffix addon. |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <nb-input-group class="max-w-80">
   <span nbInputPrefix>@</span>
@@ -25,6 +28,7 @@ import { NbInput, NbInputGroup, NbInputPrefix, NbInputSuffix } from '@ng-brutali
 ```
 
 ### Prefix and Suffix
+
 ```html
 <nb-input-group class="max-w-96">
   <span nbInputPrefix>$</span>
@@ -34,6 +38,7 @@ import { NbInput, NbInputGroup, NbInputPrefix, NbInputSuffix } from '@ng-brutali
 ```
 
 ### With Label
+
 ```html
 <div class="grid w-full max-w-96 gap-2">
   <label nbLabel for="profile-url">Profile URL</label>
@@ -45,6 +50,7 @@ import { NbInput, NbInputGroup, NbInputPrefix, NbInputSuffix } from '@ng-brutali
 ```
 
 ### Textarea
+
 ```html
 <nb-input-group class="max-w-96">
   <span nbInputPrefix align="stretch">TXT</span>
@@ -53,6 +59,7 @@ import { NbInput, NbInputGroup, NbInputPrefix, NbInputSuffix } from '@ng-brutali
 ```
 
 ### Disabled
+
 ```html
 <nb-input-group class="max-w-80">
   <span nbInputPrefix>@</span>

--- a/skills/ng-brutalism/references/input.md
+++ b/skills/ng-brutalism/references/input.md
@@ -3,23 +3,27 @@
 A form input field with hard borders, offset shadow, and strong focus states in the brutalist style.
 
 ## Import
+
 ```typescript
 import { NbInput } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Height and padding size of the input field. |
+
+| Attribute | Type                   | Default | Description                                 |
+| --------- | ---------------------- | ------- | ------------------------------------------- |
+| `size`    | `'sm' \| 'md' \| 'lg'` | `'md'`  | Height and padding size of the input field. |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <input nbInput placeholder="Email" class="w-75" />
 ```
 
 ### Sizes
+
 ```html
 <input nbInput size="sm" placeholder="Small" class="w-75" />
 <input nbInput placeholder="Default" class="w-75" />
@@ -27,11 +31,13 @@ import { NbInput } from '@ng-brutalism/ui';
 ```
 
 ### Disabled
+
 ```html
 <input nbInput placeholder="Email" class="w-75" disabled />
 ```
 
 ### With Label
+
 ```html
 <div class="flex flex-col gap-2">
   <label nbLabel for="email">Email</label>
@@ -40,6 +46,7 @@ import { NbInput } from '@ng-brutalism/ui';
 ```
 
 ### With Button
+
 ```html
 <div class="flex gap-2">
   <input nbInput placeholder="Email" class="w-75" />
@@ -48,6 +55,7 @@ import { NbInput } from '@ng-brutalism/ui';
 ```
 
 ### File Input
+
 ```html
 <input nbInput type="file" class="w-[250px]" />
 ```

--- a/skills/ng-brutalism/references/input.md
+++ b/skills/ng-brutalism/references/input.md
@@ -1,0 +1,53 @@
+# Input
+
+A form input field with hard borders, offset shadow, and strong focus states in the brutalist style.
+
+## Import
+```typescript
+import { NbInput } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Height and padding size of the input field. |
+
+## Usage Examples
+
+### Default
+```html
+<input nbInput placeholder="Email" class="w-75" />
+```
+
+### Sizes
+```html
+<input nbInput size="sm" placeholder="Small" class="w-75" />
+<input nbInput placeholder="Default" class="w-75" />
+<input nbInput size="lg" placeholder="Large" class="w-75" />
+```
+
+### Disabled
+```html
+<input nbInput placeholder="Email" class="w-75" disabled />
+```
+
+### With Label
+```html
+<div class="flex flex-col gap-2">
+  <label nbLabel for="email">Email</label>
+  <input nbInput id="email" type="email" placeholder="m@example.com" class="w-75" />
+</div>
+```
+
+### With Button
+```html
+<div class="flex gap-2">
+  <input nbInput placeholder="Email" class="w-75" />
+  <button nbButton>Subscribe</button>
+</div>
+```
+
+### File Input
+```html
+<input nbInput type="file" class="w-[250px]" />
+```

--- a/skills/ng-brutalism/references/installation.md
+++ b/skills/ng-brutalism/references/installation.md
@@ -1,0 +1,58 @@
+# Installation
+
+Add the UI package to an Angular app with the schematic, or install it manually when you want full control over each setup step.
+
+## Prerequisites
+Components are composed from Tailwind utilities applied through `nbClass`. The library expects your app to have **Tailwind CSS v4** configured and scanning your project source. The `ng add` schematic handles this automatically for Angular CLI apps.
+
+## Automatic Setup
+Use the schematic when you want the package, Tailwind CSS v4, PostCSS, and global style imports configured for you.
+```bash
+ng add @ng-brutalism/ui
+```
+
+## Manual Setup
+Use manual setup when Tailwind is already managed by your app or when you want to review each change yourself.
+```bash
+npm install @ng-brutalism/ui
+# or
+pnpm add @ng-brutalism/ui
+```
+
+## Styles
+For manual setup, import Tailwind and the bundled stylesheet once at your app's entry (e.g. `src/styles.css`). It includes the default theme tokens.
+```css
+@import "tailwindcss";
+@import '@ng-brutalism/ui/styles.css';
+```
+
+## Provider (Optional)
+The provider is only needed if you want to override theme tokens from Angular config. The simpler alternative is to redefine the CSS custom properties in your own stylesheet.
+```typescript
+import { ApplicationConfig } from '@angular/core';
+import { provideNgBrutalism } from '@ng-brutalism/ui';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideNgBrutalism({
+      theme: {
+        radius: '0px',
+        borderWidth: '3px',
+      },
+    }),
+  ],
+};
+```
+
+## Usage
+```typescript
+import { Component } from '@angular/core';
+import { NbButton } from '@ng-brutalism/ui';
+
+@Component({
+  selector: 'app-example',
+  imports: [NbButton],
+  template: `<button nbButton tone="background" style="--nb-button-bg: #fff">Ship it</button>`,
+})
+export class Example {}
+```

--- a/skills/ng-brutalism/references/installation.md
+++ b/skills/ng-brutalism/references/installation.md
@@ -3,16 +3,21 @@
 Add the UI package to an Angular app with the schematic, or install it manually when you want full control over each setup step.
 
 ## Prerequisites
+
 Components are composed from Tailwind utilities applied through `nbClass`. The library expects your app to have **Tailwind CSS v4** configured and scanning your project source. The `ng add` schematic handles this automatically for Angular CLI apps.
 
 ## Automatic Setup
+
 Use the schematic when you want the package, Tailwind CSS v4, PostCSS, and global style imports configured for you.
+
 ```bash
 ng add @ng-brutalism/ui
 ```
 
 ## Manual Setup
+
 Use manual setup when Tailwind is already managed by your app or when you want to review each change yourself.
+
 ```bash
 npm install @ng-brutalism/ui
 # or
@@ -20,14 +25,18 @@ pnpm add @ng-brutalism/ui
 ```
 
 ## Styles
+
 For manual setup, import Tailwind and the bundled stylesheet once at your app's entry (e.g. `src/styles.css`). It includes the default theme tokens.
+
 ```css
-@import "tailwindcss";
+@import 'tailwindcss';
 @import '@ng-brutalism/ui/styles.css';
 ```
 
 ## Provider (Optional)
-The provider is only needed if you want to override theme tokens from Angular config. The simpler alternative is to redefine the CSS custom properties in your own stylesheet.
+
+Use the provider only when you need to override theme tokens from Angular config. The simpler alternative is to redefine the CSS custom properties in your own stylesheet.
+
 ```typescript
 import { ApplicationConfig } from '@angular/core';
 import { provideNgBrutalism } from '@ng-brutalism/ui';
@@ -45,6 +54,7 @@ export const appConfig: ApplicationConfig = {
 ```
 
 ## Usage
+
 ```typescript
 import { Component } from '@angular/core';
 import { NbButton } from '@ng-brutalism/ui';

--- a/skills/ng-brutalism/references/label.md
+++ b/skills/ng-brutalism/references/label.md
@@ -1,0 +1,45 @@
+# Label
+
+Renders an accessible form label with bold typography and brutalist styling, associated with form controls.
+
+## Import
+```typescript
+import { NbLabel } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Selector | Description |
+|---|---|
+| `label[nbLabel]` | Applies label typography and disabled peer styling to a native label element. |
+
+## Usage Examples
+
+### Default
+```html
+<div class="flex items-center gap-2">
+  <input type="checkbox" nbCheckbox id="accept-terms" />
+  <label nbLabel for="accept-terms">Accept terms and conditions</label>
+</div>
+```
+
+### With Input
+```html
+<div class="flex flex-col gap-2">
+  <label nbLabel for="email">Email</label>
+  <input nbInput id="email" type="email" placeholder="m@example.com" class="w-75" />
+</div>
+```
+
+### Disabled Control
+```html
+<div class="flex items-center gap-2">
+  <input
+    type="checkbox"
+    nbCheckbox
+    id="disabled-terms"
+    class="peer"
+    disabled
+  />
+  <label nbLabel for="disabled-terms">Accept terms and conditions</label>
+</div>
+```

--- a/skills/ng-brutalism/references/label.md
+++ b/skills/ng-brutalism/references/label.md
@@ -3,18 +3,21 @@
 Renders an accessible form label with bold typography and brutalist styling, associated with form controls.
 
 ## Import
+
 ```typescript
 import { NbLabel } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Selector | Description |
-|---|---|
+
+| Selector         | Description                                                                   |
+| ---------------- | ----------------------------------------------------------------------------- |
 | `label[nbLabel]` | Applies label typography and disabled peer styling to a native label element. |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <div class="flex items-center gap-2">
   <input type="checkbox" nbCheckbox id="accept-terms" />
@@ -23,6 +26,7 @@ import { NbLabel } from '@ng-brutalism/ui';
 ```
 
 ### With Input
+
 ```html
 <div class="flex flex-col gap-2">
   <label nbLabel for="email">Email</label>
@@ -31,15 +35,10 @@ import { NbLabel } from '@ng-brutalism/ui';
 ```
 
 ### Disabled Control
+
 ```html
 <div class="flex items-center gap-2">
-  <input
-    type="checkbox"
-    nbCheckbox
-    id="disabled-terms"
-    class="peer"
-    disabled
-  />
+  <input type="checkbox" nbCheckbox id="disabled-terms" class="peer" disabled />
   <label nbLabel for="disabled-terms">Accept terms and conditions</label>
 </div>
 ```

--- a/skills/ng-brutalism/references/marquee.md
+++ b/skills/ng-brutalism/references/marquee.md
@@ -3,36 +3,32 @@
 A horizontally scrolling ticker that loops its content infinitely. Supports configurable speed, reverse direction, and pause on hover.
 
 ## Import
+
 ```typescript
 import { NbMarquee, NbMarqueeItem } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `duration` | `string` | `'5s'` | Animation duration (e.g. `'10s'`). Controls the speed. |
-| `reverse` | `boolean` | `false` | Reverse the scroll direction when set to true. |
-| `pauseOnHover` | `boolean` | `true` | Pause the marquee animation when the cursor hovers over it. |
+
+| Attribute      | Type      | Default | Description                                                 |
+| -------------- | --------- | ------- | ----------------------------------------------------------- |
+| `duration`     | `string`  | `'5s'`  | Animation duration (e.g. `'10s'`). Controls the speed.      |
+| `reverse`      | `boolean` | `false` | Reverse the scroll direction when set to true.              |
+| `pauseOnHover` | `boolean` | `true`  | Pause the marquee animation when the cursor hovers over it. |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <nb-marquee class="w-full" duration="10s">
   @for (skill of skills; track skill.text) {
-    <nb-marquee-item>
-      <span class="mx-4 flex items-center sm:mx-6 lg:mx-8">
-        <img
-          class="mr-2 h-7 w-7 object-contain sm:mr-3 sm:h-9 sm:w-9"
-          [src]="'https://cdn.simpleicons.org/' + skill.iconSlug + '/000000'"
-          [alt]="skill.iconLabel + ' logo'"
-          loading="lazy"
-        />
-        <span class="font-heading text-lg sm:text-xl lg:text-2xl">
-          {{ skill.text }}
-        </span>
-      </span>
-    </nb-marquee-item>
+  <nb-marquee-item>
+    <span class="mx-4 flex items-center sm:mx-6 lg:mx-8">
+      <img class="mr-2 h-7 w-7 object-contain sm:mr-3 sm:h-9 sm:w-9" [src]="'https://cdn.simpleicons.org/' + skill.iconSlug + '/000000'" [alt]="skill.iconLabel + ' logo'" loading="lazy" />
+      <span class="font-heading text-lg sm:text-xl lg:text-2xl"> {{ skill.text }} </span>
+    </span>
+  </nb-marquee-item>
   }
 </nb-marquee>
 ```
@@ -68,6 +64,7 @@ protected readonly skills: Skill[] = [
 ```
 
 ### Reverse Direction
+
 ```html
 <nb-marquee class="w-full" duration="10s" [reverse]="true">
   <!-- Items here -->
@@ -75,6 +72,7 @@ protected readonly skills: Skill[] = [
 ```
 
 ### Custom Speed
+
 ```html
 <nb-marquee class="w-full" duration="20s">
   <!-- Items here -->
@@ -82,6 +80,7 @@ protected readonly skills: Skill[] = [
 ```
 
 ### Disable Pause on Hover
+
 ```html
 <nb-marquee class="w-full" duration="10s" [pauseOnHover]="false">
   <!-- Items here -->

--- a/skills/ng-brutalism/references/marquee.md
+++ b/skills/ng-brutalism/references/marquee.md
@@ -1,0 +1,89 @@
+# Marquee
+
+A horizontally scrolling ticker that loops its content infinitely. Supports configurable speed, reverse direction, and pause on hover.
+
+## Import
+```typescript
+import { NbMarquee, NbMarqueeItem } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `duration` | `string` | `'5s'` | Animation duration (e.g. `'10s'`). Controls the speed. |
+| `reverse` | `boolean` | `false` | Reverse the scroll direction when set to true. |
+| `pauseOnHover` | `boolean` | `true` | Pause the marquee animation when the cursor hovers over it. |
+
+## Usage Examples
+
+### Default
+```html
+<nb-marquee class="w-full" duration="10s">
+  @for (skill of skills; track skill.text) {
+    <nb-marquee-item>
+      <span class="mx-4 flex items-center sm:mx-6 lg:mx-8">
+        <img
+          class="mr-2 h-7 w-7 object-contain sm:mr-3 sm:h-9 sm:w-9"
+          [src]="'https://cdn.simpleicons.org/' + skill.iconSlug + '/000000'"
+          [alt]="skill.iconLabel + ' logo'"
+          loading="lazy"
+        />
+        <span class="font-heading text-lg sm:text-xl lg:text-2xl">
+          {{ skill.text }}
+        </span>
+      </span>
+    </nb-marquee-item>
+  }
+</nb-marquee>
+```
+
+```typescript
+interface Skill {
+  text: string;
+  iconSlug: string;
+  iconLabel: string;
+}
+
+protected readonly skills: Skill[] = [
+  { text: 'ArcGIS', iconSlug: 'arcgis', iconLabel: 'ArcGIS' },
+  { text: 'QGIS', iconSlug: 'qgis', iconLabel: 'QGIS' },
+  { text: 'Docker', iconSlug: 'docker', iconLabel: 'Docker' },
+  { text: 'OpenLayers', iconSlug: 'openlayers', iconLabel: 'OpenLayers' },
+  { text: 'Leaflet', iconSlug: 'leaflet', iconLabel: 'Leaflet' },
+  { text: 'Kubernetes', iconSlug: 'kubernetes', iconLabel: 'Kubernetes' },
+  { text: 'Argo CD', iconSlug: 'argo', iconLabel: 'Argo CD' },
+  {
+    text: 'Apache Airflow',
+    iconSlug: 'apacheairflow',
+    iconLabel: 'Apache Airflow',
+  },
+  { text: 'GeoServer', iconSlug: 'osgeo', iconLabel: 'OSGeo' },
+  { text: 'Python', iconSlug: 'python', iconLabel: 'Python' },
+  { text: 'JavaScript', iconSlug: 'javascript', iconLabel: 'JavaScript' },
+  { text: 'TypeScript', iconSlug: 'typescript', iconLabel: 'TypeScript' },
+  { text: 'Angular', iconSlug: 'angular', iconLabel: 'Angular' },
+  { text: 'PostGIS', iconSlug: 'postgresql', iconLabel: 'PostgreSQL' },
+  { text: 'Version Control', iconSlug: 'git', iconLabel: 'Git' },
+];
+```
+
+### Reverse Direction
+```html
+<nb-marquee class="w-full" duration="10s" [reverse]="true">
+  <!-- Items here -->
+</nb-marquee>
+```
+
+### Custom Speed
+```html
+<nb-marquee class="w-full" duration="20s">
+  <!-- Items here -->
+</nb-marquee>
+```
+
+### Disable Pause on Hover
+```html
+<nb-marquee class="w-full" duration="10s" [pauseOnHover]="false">
+  <!-- Items here -->
+</nb-marquee>
+```

--- a/skills/ng-brutalism/references/media-frame.md
+++ b/skills/ng-brutalism/references/media-frame.md
@@ -1,0 +1,83 @@
+# Media Frame
+
+Use `nbMediaFrame` for framed visual content: images, video, illustrations, portraits, waveforms, maps, product previews, or any media-like block.
+
+## Import
+```typescript
+import { NbMediaFrame } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `tone` | `'default' \| 'cream' \| 'white' \| 'black' \| 'yellow' \| 'pink' \| 'mint' \| 'lavender' \| 'blue' \| 'primary' \| 'secondary' \| 'accent'` | `'default'` | Background color shown when content doesn't fill the frame. |
+| `ratio` | `'auto' \| '1/1' \| '3/4' \| '4/3' \| '3/2' \| '16/9' \| '21/9'` | `'auto'` | Locks the frame to the given aspect ratio. `'auto'` lets content define the height. |
+| `fit` | `'cover' \| 'contain' \| 'fill'` | `'cover'` | Object-fit applied to direct `img`, `video`, and `picture` children. |
+| `radius` | `'none' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'` | `'lg'` | Corner radius preset. Use `'full'` for circular portrait frames. |
+| `shadow` | `'none' \| 'default' \| 'hard'` | `'none'` | Offset shadow preset. `'hard'` adds a bold 6 px brutalist drop shadow. |
+
+## Usage Examples
+
+### Default
+```html
+<div nbMediaFrame>
+  <img src="/..." alt="" />
+</div>
+
+<div nbMediaFrame ratio="16/9" tone="lavender">
+  <video src="/..." />
+</div>
+
+<div nbMediaFrame ratio="1/1" fit="cover">
+  <img src="/profile.png" alt="Profile" />
+</div>
+```
+
+### Ratios
+```html
+<div nbMediaFrame ratio="1/1" tone="lavender" shadow="hard">
+  <img src="/..." alt="Square" />
+</div>
+
+<div nbMediaFrame ratio="3/4" tone="lavender" shadow="hard">
+  <img src="/..." alt="Portrait" />
+</div>
+
+<div nbMediaFrame ratio="16/9" tone="lavender" shadow="hard">
+  <img src="/..." alt="Video" />
+</div>
+
+<div nbMediaFrame ratio="21/9" tone="lavender" shadow="hard">
+  <img src="/..." alt="Cinematic" />
+</div>
+```
+
+### Fit
+```html
+<div nbMediaFrame ratio="16/9" tone="mint" fit="cover">
+  <img src="/..." alt="" />
+</div>
+
+<div nbMediaFrame ratio="16/9" tone="mint" fit="contain">
+  <img src="/..." alt="" />
+</div>
+
+<div nbMediaFrame ratio="16/9" tone="mint" fit="fill">
+  <img src="/..." alt="" />
+</div>
+```
+
+### Shape
+```html
+<div nbMediaFrame ratio="1/1" tone="yellow" radius="none" shadow="none" class="w-48">
+  <img src="/..." alt="Sharp" />
+</div>
+
+<div nbMediaFrame ratio="1/1" tone="lavender" radius="lg" shadow="default" class="w-48">
+  <img src="/..." alt="Poster" />
+</div>
+
+<div nbMediaFrame ratio="1/1" tone="pink" radius="full" shadow="hard" class="w-48">
+  <img src="/..." alt="Portrait" />
+</div>
+```

--- a/skills/ng-brutalism/references/media-frame.md
+++ b/skills/ng-brutalism/references/media-frame.md
@@ -3,22 +3,25 @@
 Use `nbMediaFrame` for framed visual content: images, video, illustrations, portraits, waveforms, maps, product previews, or any media-like block.
 
 ## Import
+
 ```typescript
 import { NbMediaFrame } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `tone` | `'default' \| 'cream' \| 'white' \| 'black' \| 'yellow' \| 'pink' \| 'mint' \| 'lavender' \| 'blue' \| 'primary' \| 'secondary' \| 'accent'` | `'default'` | Background color shown when content doesn't fill the frame. |
-| `ratio` | `'auto' \| '1/1' \| '3/4' \| '4/3' \| '3/2' \| '16/9' \| '21/9'` | `'auto'` | Locks the frame to the given aspect ratio. `'auto'` lets content define the height. |
-| `fit` | `'cover' \| 'contain' \| 'fill'` | `'cover'` | Object-fit applied to direct `img`, `video`, and `picture` children. |
-| `radius` | `'none' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'` | `'lg'` | Corner radius preset. Use `'full'` for circular portrait frames. |
-| `shadow` | `'none' \| 'default' \| 'hard'` | `'none'` | Offset shadow preset. `'hard'` adds a bold 6 px brutalist drop shadow. |
+
+| Attribute | Type                                                                                                                                         | Default     | Description                                                                         |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ----------- | ----------------------------------------------------------------------------------- |
+| `tone`    | `'default' \| 'cream' \| 'white' \| 'black' \| 'yellow' \| 'pink' \| 'mint' \| 'lavender' \| 'blue' \| 'primary' \| 'secondary' \| 'accent'` | `'default'` | Background color shown when content doesn't fill the frame.                         |
+| `ratio`   | `'auto' \| '1/1' \| '3/4' \| '4/3' \| '3/2' \| '16/9' \| '21/9'`                                                                             | `'auto'`    | Locks the frame to the given aspect ratio. `'auto'` lets content define the height. |
+| `fit`     | `'cover' \| 'contain' \| 'fill'`                                                                                                             | `'cover'`   | Object-fit applied to direct `img`, `video`, and `picture` children.                |
+| `radius`  | `'none' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'`                                                                                           | `'lg'`      | Corner radius preset. Use `'full'` for circular portrait frames.                    |
+| `shadow`  | `'none' \| 'default' \| 'hard'`                                                                                                              | `'none'`    | Offset shadow preset. `'hard'` adds a bold 6 px brutalist drop shadow.              |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <div nbMediaFrame>
   <img src="/..." alt="" />
@@ -34,6 +37,7 @@ import { NbMediaFrame } from '@ng-brutalism/ui';
 ```
 
 ### Ratios
+
 ```html
 <div nbMediaFrame ratio="1/1" tone="lavender" shadow="hard">
   <img src="/..." alt="Square" />
@@ -53,6 +57,7 @@ import { NbMediaFrame } from '@ng-brutalism/ui';
 ```
 
 ### Fit
+
 ```html
 <div nbMediaFrame ratio="16/9" tone="mint" fit="cover">
   <img src="/..." alt="" />
@@ -68,6 +73,7 @@ import { NbMediaFrame } from '@ng-brutalism/ui';
 ```
 
 ### Shape
+
 ```html
 <div nbMediaFrame ratio="1/1" tone="yellow" radius="none" shadow="none" class="w-48">
   <img src="/..." alt="Sharp" />

--- a/skills/ng-brutalism/references/media-item.md
+++ b/skills/ng-brutalism/references/media-item.md
@@ -1,0 +1,241 @@
+# Media Item
+
+Use `nb-media-item` to pair an icon or image with a title and optional description. Covers feature lists, event details, product specs, flight info, contact rows, status chips, and any layout that anchors text next to a visual.
+
+## Import
+```typescript
+import { NbMediaItem, NbMediaItemTitle, NbSeparator, NbSurface } from '@ng-brutalism/ui';
+```
+
+## API Reference
+
+### Inputs (nb-media-item)
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `variant` | `'plain' \| 'boxed' \| 'chip'` | `'plain'` | Visual container style. `boxed` adds a border and shadow; `chip` uses a fully-rounded pill shape. |
+| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Controls whether the media and text stack side-by-side or top-to-bottom. |
+| `align` | `'start' \| 'center' \| 'between'` | `'start'` | Horizontal distribution of children. `between` stretches the item to full width. |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Sets gap, padding, icon size, and font size together. |
+| `tone` | `NbToneToken` | `'default'` | Shared color tone — writes background, foreground, and border color. Background paint applies to `boxed` and `chip` variants. |
+| `icon` | `string` | `undefined` | Image source for the media icon. |
+| `iconAlt` | `string` | `''` | Accessible alternative text for the input icon. |
+| `iconBackground` | `string` | `undefined` | Wraps the input icon in a framed surface with the provided fill. |
+| `title` | `string` | `undefined` | Primary label. Use `nbMediaItemTitle` for custom title markup. |
+| `description` | `string` | `undefined` | Secondary label. Use `nbMediaItemDescription` for custom description markup. |
+
+### CSS Tokens
+| Token | Default | Description |
+|---|---|---|
+| `--nb-media-item-icon-size` | Depends on `size` | Controls projected and input icon dimensions. |
+| `--nb-media-item-title-size` | Depends on `size` | Controls title text size for input and projected titles. |
+| `--nb-media-item-title-font-family` | `var(--font-sans)` | Controls title font family without adding utility classes to the title slot. |
+| `--nb-media-item-description-size` | Depends on `size` | Controls secondary label text size. |
+
+### Sub-directives
+| Directive | Description |
+|---|---|
+| `nbMediaItemIcon` | Media slot for an icon or image. Add `surface` to use the built-in icon frame and `background` to adjust its fill. |
+| `nbMediaItemTitle` | Primary label. Rendered in black font weight with tight leading. |
+| `nbMediaItemDescription` | Secondary label below the title. Rendered at 75% size with reduced opacity. |
+
+## Usage Examples
+
+### Default
+```html
+<div nbSurface border="strong" layout="stack" radius="sm" shadow="hard" clip>
+  <div class="border-b-2 border-(--nb-border) bg-(--nb-accent) px-4 py-3 text-(--nb-accent-foreground)">
+    <span class="font-heading text-2xl uppercase leading-none">Your Flight</span>
+  </div>
+
+  <div class="flex flex-col p-4">
+    <nb-media-item
+      variant="plain"
+      class="pb-3"
+      style="--nb-media-item-icon-size: 2.5rem; --nb-media-item-title-size: 3rem; --nb-media-item-title-font-family: var(--font-heading)"
+      icon="/icons/plane.png"
+      iconAlt="Flight"
+      description="Jun 14 · 22:15 → 12:45+1"
+    >
+      <span nbMediaItemTitle>NYC → CDG</span>
+    </nb-media-item>
+
+    <div class="flex flex-col gap-2">
+      <hr nbSeparator variant="dashed" />
+
+      <nb-media-item
+        variant="plain"
+        icon="/icons/ticket.png"
+        iconAlt="Ticket"
+        iconBackground="#ff6aa2"
+        title="Seat 14A"
+        description="Economy · Window"
+      />
+
+      <hr nbSeparator />
+
+      <nb-media-item
+        variant="plain"
+        icon="/icons/baggage.png"
+        iconAlt="Baggage"
+        iconBackground="#dcc8ff"
+        title="1 checked bag"
+        description="23 kg max"
+      />
+    </div>
+  </div>
+</div>
+```
+
+### Variants
+```html
+<!-- plain: no container, just layout -->
+<nb-media-item
+  variant="plain"
+  size="md"
+  icon="/icons/star.png"
+  iconAlt="Star"
+  title="Premium Access"
+  description="Unlimited features"
+/>
+
+<!-- boxed: border + offset shadow -->
+<nb-media-item
+  variant="boxed"
+  size="md"
+  tone="yellow"
+  icon="/icons/star.png"
+  iconAlt="Star"
+  title="Premium Access"
+  description="Unlimited features"
+/>
+
+<!-- chip: fully-rounded pill -->
+<nb-media-item
+  variant="chip"
+  size="md"
+  tone="yellow"
+  icon="/icons/star.png"
+  iconAlt="Star"
+  title="Premium Access"
+  description="Unlimited features"
+/>
+```
+
+### Orientations
+```html
+<nb-media-item
+  orientation="horizontal"
+  variant="boxed"
+  size="md"
+  tone="lavender"
+  icon="/icons/camera.png"
+  iconAlt="Camera"
+  title="Travel Photos"
+  description="128 shots"
+/>
+
+<nb-media-item
+  orientation="vertical"
+  variant="boxed"
+  size="md"
+  tone="lavender"
+  icon="/icons/camera.png"
+  iconAlt="Camera"
+  title="Travel Photos"
+  description="128 shots"
+/>
+```
+
+### With Description
+```html
+<!-- title only -->
+<nb-media-item
+  variant="plain"
+  size="md"
+  icon="/icons/ticket.png"
+  iconAlt="Ticket"
+  title="Boarding Pass"
+/>
+
+<!-- title + description -->
+<nb-media-item
+  variant="plain"
+  size="md"
+  icon="/icons/ticket.png"
+  iconAlt="Ticket"
+  title="Boarding Pass"
+  description="Seat 14A · Economy"
+/>
+```
+
+### Sizes
+```html
+<nb-media-item
+  variant="boxed"
+  size="sm"
+  tone="cream"
+  icon="/icons/baggage.png"
+  iconAlt="Baggage"
+  title="SM — Checked Baggage"
+  description="Up to 23kg included"
+/>
+
+<nb-media-item
+  variant="boxed"
+  size="md"
+  tone="cream"
+  icon="/icons/baggage.png"
+  iconAlt="Baggage"
+  title="MD — Checked Baggage"
+  description="Up to 23kg included"
+/>
+
+<nb-media-item
+  variant="boxed"
+  size="lg"
+  tone="cream"
+  icon="/icons/baggage.png"
+  iconAlt="Baggage"
+  title="LG — Checked Baggage"
+  description="Up to 23kg included"
+/>
+```
+
+### Alignment
+```html
+<!-- start (default) -->
+<nb-media-item
+  variant="boxed"
+  size="md"
+  tone="yellow"
+  align="start"
+  icon="/icons/world.png"
+  iconAlt="World"
+  title="Global Network"
+  description="140+ destinations"
+/>
+
+<!-- center -->
+<nb-media-item
+  variant="boxed"
+  size="md"
+  tone="yellow"
+  align="center"
+  icon="/icons/world.png"
+  iconAlt="World"
+  title="Global Network"
+  description="140+ destinations"
+/>
+
+<!-- between: stretches to full width -->
+<nb-media-item
+  variant="boxed"
+  size="md"
+  tone="yellow"
+  align="between"
+  icon="/icons/world.png"
+  iconAlt="World"
+  title="Global Network"
+  description="140+ destinations"
+/>
+```

--- a/skills/ng-brutalism/references/media-item.md
+++ b/skills/ng-brutalism/references/media-item.md
@@ -3,6 +3,7 @@
 Use `nb-media-item` to pair an icon or image with a title and optional description. Covers feature lists, event details, product specs, flight info, contact rows, status chips, and any layout that anchors text next to a visual.
 
 ## Import
+
 ```typescript
 import { NbMediaItem, NbMediaItemTitle, NbSeparator, NbSurface } from '@ng-brutalism/ui';
 ```
@@ -10,37 +11,41 @@ import { NbMediaItem, NbMediaItemTitle, NbSeparator, NbSurface } from '@ng-bruta
 ## API Reference
 
 ### Inputs (nb-media-item)
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `variant` | `'plain' \| 'boxed' \| 'chip'` | `'plain'` | Visual container style. `boxed` adds a border and shadow; `chip` uses a fully-rounded pill shape. |
-| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Controls whether the media and text stack side-by-side or top-to-bottom. |
-| `align` | `'start' \| 'center' \| 'between'` | `'start'` | Horizontal distribution of children. `between` stretches the item to full width. |
-| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Sets gap, padding, icon size, and font size together. |
-| `tone` | `NbToneToken` | `'default'` | Shared color tone — writes background, foreground, and border color. Background paint applies to `boxed` and `chip` variants. |
-| `icon` | `string` | `undefined` | Image source for the media icon. |
-| `iconAlt` | `string` | `''` | Accessible alternative text for the input icon. |
-| `iconBackground` | `string` | `undefined` | Wraps the input icon in a framed surface with the provided fill. |
-| `title` | `string` | `undefined` | Primary label. Use `nbMediaItemTitle` for custom title markup. |
-| `description` | `string` | `undefined` | Secondary label. Use `nbMediaItemDescription` for custom description markup. |
+
+| Attribute        | Type                               | Default        | Description                                                                                                                   |
+| ---------------- | ---------------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `variant`        | `'plain' \| 'boxed' \| 'chip'`     | `'plain'`      | Visual container style. `boxed` adds a border and shadow; `chip` uses a fully-rounded pill shape.                             |
+| `orientation`    | `'horizontal' \| 'vertical'`       | `'horizontal'` | Controls whether the media and text stack side-by-side or top-to-bottom.                                                      |
+| `align`          | `'start' \| 'center' \| 'between'` | `'start'`      | Horizontal distribution of children. `between` stretches the item to full width.                                              |
+| `size`           | `'sm' \| 'md' \| 'lg'`             | `'md'`         | Sets gap, padding, icon size, and font size together.                                                                         |
+| `tone`           | `NbToneToken`                      | `'default'`    | Shared color tone — writes background, foreground, and border color. Background paint applies to `boxed` and `chip` variants. |
+| `icon`           | `string`                           | `undefined`    | Image source for the media icon.                                                                                              |
+| `iconAlt`        | `string`                           | `''`           | Accessible alternative text for the input icon.                                                                               |
+| `iconBackground` | `string`                           | `undefined`    | Wraps the input icon in a framed surface with the provided fill.                                                              |
+| `title`          | `string`                           | `undefined`    | Primary label. Use `nbMediaItemTitle` for custom title markup.                                                                |
+| `description`    | `string`                           | `undefined`    | Secondary label. Use `nbMediaItemDescription` for custom description markup.                                                  |
 
 ### CSS Tokens
-| Token | Default | Description |
-|---|---|---|
-| `--nb-media-item-icon-size` | Depends on `size` | Controls projected and input icon dimensions. |
-| `--nb-media-item-title-size` | Depends on `size` | Controls title text size for input and projected titles. |
+
+| Token                               | Default            | Description                                                                  |
+| ----------------------------------- | ------------------ | ---------------------------------------------------------------------------- |
+| `--nb-media-item-icon-size`         | Depends on `size`  | Controls projected and input icon dimensions.                                |
+| `--nb-media-item-title-size`        | Depends on `size`  | Controls title text size for input and projected titles.                     |
 | `--nb-media-item-title-font-family` | `var(--font-sans)` | Controls title font family without adding utility classes to the title slot. |
-| `--nb-media-item-description-size` | Depends on `size` | Controls secondary label text size. |
+| `--nb-media-item-description-size`  | Depends on `size`  | Controls secondary label text size.                                          |
 
 ### Sub-directives
-| Directive | Description |
-|---|---|
-| `nbMediaItemIcon` | Media slot for an icon or image. Add `surface` to use the built-in icon frame and `background` to adjust its fill. |
-| `nbMediaItemTitle` | Primary label. Rendered in black font weight with tight leading. |
-| `nbMediaItemDescription` | Secondary label below the title. Rendered at 75% size with reduced opacity. |
+
+| Directive                | Description                                                                                                        |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `nbMediaItemIcon`        | Media slot for an icon or image. Add `surface` to use the built-in icon frame and `background` to adjust its fill. |
+| `nbMediaItemTitle`       | Primary label. Rendered in black font weight with tight leading.                                                   |
+| `nbMediaItemDescription` | Secondary label below the title. Rendered at 75% size with reduced opacity.                                        |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <div nbSurface border="strong" layout="stack" radius="sm" shadow="hard" clip>
   <div class="border-b-2 border-(--nb-border) bg-(--nb-accent) px-4 py-3 text-(--nb-accent-foreground)">
@@ -48,194 +53,73 @@ import { NbMediaItem, NbMediaItemTitle, NbSeparator, NbSurface } from '@ng-bruta
   </div>
 
   <div class="flex flex-col p-4">
-    <nb-media-item
-      variant="plain"
-      class="pb-3"
-      style="--nb-media-item-icon-size: 2.5rem; --nb-media-item-title-size: 3rem; --nb-media-item-title-font-family: var(--font-heading)"
-      icon="/icons/plane.png"
-      iconAlt="Flight"
-      description="Jun 14 · 22:15 → 12:45+1"
-    >
+    <nb-media-item variant="plain" class="pb-3" style="--nb-media-item-icon-size: 2.5rem; --nb-media-item-title-size: 3rem; --nb-media-item-title-font-family: var(--font-heading)" icon="/icons/plane.png" iconAlt="Flight" description="Jun 14 · 22:15 → 12:45+1">
       <span nbMediaItemTitle>NYC → CDG</span>
     </nb-media-item>
 
     <div class="flex flex-col gap-2">
       <hr nbSeparator variant="dashed" />
 
-      <nb-media-item
-        variant="plain"
-        icon="/icons/ticket.png"
-        iconAlt="Ticket"
-        iconBackground="#ff6aa2"
-        title="Seat 14A"
-        description="Economy · Window"
-      />
+      <nb-media-item variant="plain" icon="/icons/ticket.png" iconAlt="Ticket" iconBackground="#ff6aa2" title="Seat 14A" description="Economy · Window" />
 
       <hr nbSeparator />
 
-      <nb-media-item
-        variant="plain"
-        icon="/icons/baggage.png"
-        iconAlt="Baggage"
-        iconBackground="#dcc8ff"
-        title="1 checked bag"
-        description="23 kg max"
-      />
+      <nb-media-item variant="plain" icon="/icons/baggage.png" iconAlt="Baggage" iconBackground="#dcc8ff" title="1 checked bag" description="23 kg max" />
     </div>
   </div>
 </div>
 ```
 
 ### Variants
+
 ```html
 <!-- plain: no container, just layout -->
-<nb-media-item
-  variant="plain"
-  size="md"
-  icon="/icons/star.png"
-  iconAlt="Star"
-  title="Premium Access"
-  description="Unlimited features"
-/>
+<nb-media-item variant="plain" size="md" icon="/icons/star.png" iconAlt="Star" title="Premium Access" description="Unlimited features" />
 
 <!-- boxed: border + offset shadow -->
-<nb-media-item
-  variant="boxed"
-  size="md"
-  tone="yellow"
-  icon="/icons/star.png"
-  iconAlt="Star"
-  title="Premium Access"
-  description="Unlimited features"
-/>
+<nb-media-item variant="boxed" size="md" tone="yellow" icon="/icons/star.png" iconAlt="Star" title="Premium Access" description="Unlimited features" />
 
 <!-- chip: fully-rounded pill -->
-<nb-media-item
-  variant="chip"
-  size="md"
-  tone="yellow"
-  icon="/icons/star.png"
-  iconAlt="Star"
-  title="Premium Access"
-  description="Unlimited features"
-/>
+<nb-media-item variant="chip" size="md" tone="yellow" icon="/icons/star.png" iconAlt="Star" title="Premium Access" description="Unlimited features" />
 ```
 
 ### Orientations
-```html
-<nb-media-item
-  orientation="horizontal"
-  variant="boxed"
-  size="md"
-  tone="lavender"
-  icon="/icons/camera.png"
-  iconAlt="Camera"
-  title="Travel Photos"
-  description="128 shots"
-/>
 
-<nb-media-item
-  orientation="vertical"
-  variant="boxed"
-  size="md"
-  tone="lavender"
-  icon="/icons/camera.png"
-  iconAlt="Camera"
-  title="Travel Photos"
-  description="128 shots"
-/>
+```html
+<nb-media-item orientation="horizontal" variant="boxed" size="md" tone="lavender" icon="/icons/camera.png" iconAlt="Camera" title="Travel Photos" description="128 shots" />
+
+<nb-media-item orientation="vertical" variant="boxed" size="md" tone="lavender" icon="/icons/camera.png" iconAlt="Camera" title="Travel Photos" description="128 shots" />
 ```
 
 ### With Description
+
 ```html
 <!-- title only -->
-<nb-media-item
-  variant="plain"
-  size="md"
-  icon="/icons/ticket.png"
-  iconAlt="Ticket"
-  title="Boarding Pass"
-/>
+<nb-media-item variant="plain" size="md" icon="/icons/ticket.png" iconAlt="Ticket" title="Boarding Pass" />
 
 <!-- title + description -->
-<nb-media-item
-  variant="plain"
-  size="md"
-  icon="/icons/ticket.png"
-  iconAlt="Ticket"
-  title="Boarding Pass"
-  description="Seat 14A · Economy"
-/>
+<nb-media-item variant="plain" size="md" icon="/icons/ticket.png" iconAlt="Ticket" title="Boarding Pass" description="Seat 14A · Economy" />
 ```
 
 ### Sizes
+
 ```html
-<nb-media-item
-  variant="boxed"
-  size="sm"
-  tone="cream"
-  icon="/icons/baggage.png"
-  iconAlt="Baggage"
-  title="SM — Checked Baggage"
-  description="Up to 23kg included"
-/>
+<nb-media-item variant="boxed" size="sm" tone="cream" icon="/icons/baggage.png" iconAlt="Baggage" title="SM — Checked Baggage" description="Up to 23kg included" />
 
-<nb-media-item
-  variant="boxed"
-  size="md"
-  tone="cream"
-  icon="/icons/baggage.png"
-  iconAlt="Baggage"
-  title="MD — Checked Baggage"
-  description="Up to 23kg included"
-/>
+<nb-media-item variant="boxed" size="md" tone="cream" icon="/icons/baggage.png" iconAlt="Baggage" title="MD — Checked Baggage" description="Up to 23kg included" />
 
-<nb-media-item
-  variant="boxed"
-  size="lg"
-  tone="cream"
-  icon="/icons/baggage.png"
-  iconAlt="Baggage"
-  title="LG — Checked Baggage"
-  description="Up to 23kg included"
-/>
+<nb-media-item variant="boxed" size="lg" tone="cream" icon="/icons/baggage.png" iconAlt="Baggage" title="LG — Checked Baggage" description="Up to 23kg included" />
 ```
 
 ### Alignment
+
 ```html
 <!-- start (default) -->
-<nb-media-item
-  variant="boxed"
-  size="md"
-  tone="yellow"
-  align="start"
-  icon="/icons/world.png"
-  iconAlt="World"
-  title="Global Network"
-  description="140+ destinations"
-/>
+<nb-media-item variant="boxed" size="md" tone="yellow" align="start" icon="/icons/world.png" iconAlt="World" title="Global Network" description="140+ destinations" />
 
 <!-- center -->
-<nb-media-item
-  variant="boxed"
-  size="md"
-  tone="yellow"
-  align="center"
-  icon="/icons/world.png"
-  iconAlt="World"
-  title="Global Network"
-  description="140+ destinations"
-/>
+<nb-media-item variant="boxed" size="md" tone="yellow" align="center" icon="/icons/world.png" iconAlt="World" title="Global Network" description="140+ destinations" />
 
 <!-- between: stretches to full width -->
-<nb-media-item
-  variant="boxed"
-  size="md"
-  tone="yellow"
-  align="between"
-  icon="/icons/world.png"
-  iconAlt="World"
-  title="Global Network"
-  description="140+ destinations"
-/>
+<nb-media-item variant="boxed" size="md" tone="yellow" align="between" icon="/icons/world.png" iconAlt="World" title="Global Network" description="140+ destinations" />
 ```

--- a/skills/ng-brutalism/references/overview.md
+++ b/skills/ng-brutalism/references/overview.md
@@ -5,67 +5,62 @@ A composition system for building loud, token-driven, Angular-first brutalist UI
 Every ng-brutalism UI starts with a surface. Regions inside that surface are sections. Content flows vertically in stacks and horizontally in clusters. Two-column layouts use split. Actions and metadata complete the picture.
 
 ## Import
+
 ```typescript
-import {
-  NbButton,
-  NbChip,
-  NbCluster,
-  NbDisplay,
-  NbSection,
-  NbSplit,
-  NbStack,
-  NbSurface,
-  NbText,
-  NbTitle
-} from '@ng-brutalism/ui';
+import { NbButton, NbChip, NbCluster, NbDisplay, NbSection, NbSplit, NbStack, NbSurface, NbText, NbTitle } from '@ng-brutalism/ui';
 ```
 
 ## Mental Model & Primitives
-* **nbSurface**: The brutalist panel container
-* **nbSection**: Structural regions inside a panel (e.g. header, body, footer)
-* **nbStack**: Vertical layout flow
-* **nbCluster**: Horizontal / wrapping groups
-* **nbSplit**: Main + aside two-column layout
-* **nbButton**: Action primitive
-* **nbChip**: Small metadata primitive
-* **nbText**: Inline or block copy
-* **nbTitle**: Section headings
-* **nbDisplay**: Big, loud display headings
+
+- **nbSurface**: The brutalist panel container
+- **nbSection**: Structural regions inside a panel (e.g. header, body, footer)
+- **nbStack**: Vertical layout flow
+- **nbCluster**: Horizontal / wrapping groups
+- **nbSplit**: Main + aside two-column layout
+- **nbButton**: Action primitive
+- **nbChip**: Small metadata primitive
+- **nbText**: Inline or block copy
+- **nbTitle**: Section headings
+- **nbDisplay**: Big, loud display headings
 
 ## Decision Guide
-| Need | Primitive |
-|---|---|
-| Need a panel? | `nbSurface` |
-| Need header / body / footer inside a panel? | `nbSection` |
-| Need vertical spacing? | `nbStack` |
-| Need horizontal or wrapping items? | `nbCluster` |
-| Need two columns or main/aside? | `nbSplit` |
-| Need an action? | `nbButton` or `nbIconButton` |
-| Need metadata? | `nbChip` or `nbBadge` |
-| Need emphasis text? | `nbTitle`, `nbDisplay`, or `nbText` |
-| Need status? | `nbStatusDot`, `nbBadge`, or `nbCallout` |
+
+| Need                                        | Primitive                                |
+| ------------------------------------------- | ---------------------------------------- |
+| Need a panel?                               | `nbSurface`                              |
+| Need header / body / footer inside a panel? | `nbSection`                              |
+| Need vertical spacing?                      | `nbStack`                                |
+| Need horizontal or wrapping items?          | `nbCluster`                              |
+| Need two columns or main/aside?             | `nbSplit`                                |
+| Need an action?                             | `nbButton` or `nbIconButton`             |
+| Need metadata?                              | `nbChip` or `nbBadge`                    |
+| Need emphasis text?                         | `nbTitle`, `nbDisplay`, or `nbText`      |
+| Need status?                                | `nbStatusDot`, `nbBadge`, or `nbCallout` |
 
 ## API Language
-Every primitive in ng-brutalism shares the same token vocabulary:
 
-| Token | Description |
-|---|---|
-| `tone` | Visual intent / color theme |
-| `size` | Component scale |
-| `radius` | Corner shape |
-| `shadow` | Brutalist offset depth |
-| `border` | Outline strength |
-| `padding` | Internal space |
-| `gap` | Child spacing |
-| `align` | Cross-axis alignment |
-| `justify` | Main-axis alignment |
-| `collapse` | Responsive layout behavior |
-| `clip` | Keep inner regions inside the outer radius |
-| `divider` | Border between regions — top, bottom, etc. |
+Most primitives in ng-brutalism share a core token vocabulary. Component-specific properties are documented in each component reference.
+
+| Token     | Description                                                                                                         |
+| --------- | ------------------------------------------------------------------------------------------------------------------- |
+| `tone`    | Visual intent / color theme, including `default`, `surface`, `background`, `ink`, playful tones, and semantic tones |
+| `size`    | Component scale                                                                                                     |
+| `radius`  | Corner shape                                                                                                        |
+| `shadow`  | Brutalist offset depth                                                                                              |
+| `border`  | Outline strength                                                                                                    |
+| `padding` | Internal space                                                                                                      |
+| `gap`     | Child spacing                                                                                                       |
+| `align`   | Cross-axis alignment                                                                                                |
+| `justify` | Main-axis alignment                                                                                                 |
+| `clip`    | Keep inner regions inside the outer radius                                                                          |
+| `divider` | Border between regions — top, bottom, etc.                                                                          |
+
+Common component-specific properties in the examples include `layout`, `collapse`, `weight`, `leading`, `tracking`, `transform`, `underline`, and `underlineGap`.
 
 ## Usage Examples
 
 ### Launch Panel
+
 ```html
 <article nbSurface tone="cream" radius="xl" shadow="hard" border="strong" clip class="w-full max-w-xl">
   <header nbSection padding="lg" divider="bottom">
@@ -77,10 +72,7 @@ Every primitive in ng-brutalism shares the same token vocabulary:
 
   <div nbSection padding="lg">
     <div nbStack gap="md">
-      <p nbText>
-        Build a loud release panel using composition primitives
-        instead of class-heavy wrappers.
-      </p>
+      <p nbText>Build a loud release panel using composition primitives instead of class-heavy wrappers.</p>
 
       <div nbCluster gap="xs">
         <span nbChip tone="yellow">Surface</span>
@@ -99,7 +91,9 @@ Every primitive in ng-brutalism shares the same token vocabulary:
 ```
 
 ### Before vs After (Tailwind vs Composition)
+
 #### Before (Class Soup)
+
 ```html
 <div class="rounded-2xl border-4 border-black bg-yellow-300 p-6 shadow-[8px_8px_0_#000]">
   <div class="flex items-center justify-between border-b-4 border-black pb-4">
@@ -114,6 +108,7 @@ Every primitive in ng-brutalism shares the same token vocabulary:
 ```
 
 #### After (Composition)
+
 ```html
 <article nbSurface tone="yellow" radius="xl" shadow="hard" clip>
   <header nbSection padding="lg" divider="bottom" layout="between" align="center">
@@ -128,26 +123,14 @@ Every primitive in ng-brutalism shares the same token vocabulary:
 ```
 
 ### Customization
+
 ```html
 <!-- Step 1: use public inputs first -->
-<div nbSurface tone="cream" radius="xl" shadow="hard">
-  Token-driven surface
-</div>
+<div nbSurface tone="cream" radius="xl" shadow="hard">Token-driven surface</div>
 
 <!-- Step 2: CSS variables for fine-grained control -->
-<div
-  nbSurface
-  tone="cream"
-  style="--nb-surface-bg: #faf6f0"
->
-  Custom surface background
-</div>
+<div nbSurface tone="cream" style="--nb-surface-bg: #faf6f0">Custom surface background</div>
 
 <!-- Overrides are local — only this element is affected -->
-<div
-  nbSurface
-  style="--nb-shadow-offset-x: 12px; --nb-shadow-offset-y: 12px"
->
-  Custom shadow offset
-</div>
+<div nbSurface style="--nb-shadow-offset-x: 12px; --nb-shadow-offset-y: 12px">Custom shadow offset</div>
 ```

--- a/skills/ng-brutalism/references/overview.md
+++ b/skills/ng-brutalism/references/overview.md
@@ -1,0 +1,153 @@
+# Composition Overview
+
+A composition system for building loud, token-driven, Angular-first brutalist UIs. Small primitives lock together like LEGO — each primitive owns one job, and they compose to build anything.
+
+Every ng-brutalism UI starts with a surface. Regions inside that surface are sections. Content flows vertically in stacks and horizontally in clusters. Two-column layouts use split. Actions and metadata complete the picture.
+
+## Import
+```typescript
+import {
+  NbButton,
+  NbChip,
+  NbCluster,
+  NbDisplay,
+  NbSection,
+  NbSplit,
+  NbStack,
+  NbSurface,
+  NbText,
+  NbTitle
+} from '@ng-brutalism/ui';
+```
+
+## Mental Model & Primitives
+* **nbSurface**: The brutalist panel container
+* **nbSection**: Structural regions inside a panel (e.g. header, body, footer)
+* **nbStack**: Vertical layout flow
+* **nbCluster**: Horizontal / wrapping groups
+* **nbSplit**: Main + aside two-column layout
+* **nbButton**: Action primitive
+* **nbChip**: Small metadata primitive
+* **nbText**: Inline or block copy
+* **nbTitle**: Section headings
+* **nbDisplay**: Big, loud display headings
+
+## Decision Guide
+| Need | Primitive |
+|---|---|
+| Need a panel? | `nbSurface` |
+| Need header / body / footer inside a panel? | `nbSection` |
+| Need vertical spacing? | `nbStack` |
+| Need horizontal or wrapping items? | `nbCluster` |
+| Need two columns or main/aside? | `nbSplit` |
+| Need an action? | `nbButton` or `nbIconButton` |
+| Need metadata? | `nbChip` or `nbBadge` |
+| Need emphasis text? | `nbTitle`, `nbDisplay`, or `nbText` |
+| Need status? | `nbStatusDot`, `nbBadge`, or `nbCallout` |
+
+## API Language
+Every primitive in ng-brutalism shares the same token vocabulary:
+
+| Token | Description |
+|---|---|
+| `tone` | Visual intent / color theme |
+| `size` | Component scale |
+| `radius` | Corner shape |
+| `shadow` | Brutalist offset depth |
+| `border` | Outline strength |
+| `padding` | Internal space |
+| `gap` | Child spacing |
+| `align` | Cross-axis alignment |
+| `justify` | Main-axis alignment |
+| `collapse` | Responsive layout behavior |
+| `clip` | Keep inner regions inside the outer radius |
+| `divider` | Border between regions — top, bottom, etc. |
+
+## Usage Examples
+
+### Launch Panel
+```html
+<article nbSurface tone="cream" radius="xl" shadow="hard" border="strong" clip class="w-full max-w-xl">
+  <header nbSection padding="lg" divider="bottom">
+    <div nbCluster gap="sm" align="center" justify="between">
+      <h2 nbTitle>Launch checklist</h2>
+      <span nbChip tone="yellow">v0.2.0</span>
+    </div>
+  </header>
+
+  <div nbSection padding="lg">
+    <div nbStack gap="md">
+      <p nbText>
+        Build a loud release panel using composition primitives
+        instead of class-heavy wrappers.
+      </p>
+
+      <div nbCluster gap="xs">
+        <span nbChip tone="yellow">Surface</span>
+        <span nbChip tone="pink">Section</span>
+        <span nbChip tone="mint">Stack</span>
+        <span nbChip tone="lavender">Cluster</span>
+      </div>
+    </div>
+  </div>
+
+  <footer nbSection padding="lg" divider="top" layout="between" align="center">
+    <span nbText tone="muted">Ready for release</span>
+    <button nbButton tone="black">Ship it</button>
+  </footer>
+</article>
+```
+
+### Before vs After (Tailwind vs Composition)
+#### Before (Class Soup)
+```html
+<div class="rounded-2xl border-4 border-black bg-yellow-300 p-6 shadow-[8px_8px_0_#000]">
+  <div class="flex items-center justify-between border-b-4 border-black pb-4">
+    <h2>Launch card</h2>
+    <span>v0.2.0</span>
+  </div>
+
+  <div class="py-4">
+    <p>Lots of repeated class decisions.</p>
+  </div>
+</div>
+```
+
+#### After (Composition)
+```html
+<article nbSurface tone="yellow" radius="xl" shadow="hard" clip>
+  <header nbSection padding="lg" divider="bottom" layout="between" align="center">
+    <h2 nbTitle>Launch card</h2>
+    <span nbChip tone="pink">v0.2.0</span>
+  </header>
+
+  <div nbSection padding="lg">
+    <p nbText>Same structure, clearer composition.</p>
+  </div>
+</article>
+```
+
+### Customization
+```html
+<!-- Step 1: use public inputs first -->
+<div nbSurface tone="cream" radius="xl" shadow="hard">
+  Token-driven surface
+</div>
+
+<!-- Step 2: CSS variables for fine-grained control -->
+<div
+  nbSurface
+  tone="cream"
+  style="--nb-surface-bg: #faf6f0"
+>
+  Custom surface background
+</div>
+
+<!-- Overrides are local — only this element is affected -->
+<div
+  nbSurface
+  style="--nb-shadow-offset-x: 12px; --nb-shadow-offset-y: 12px"
+>
+  Custom shadow offset
+</div>
+```

--- a/skills/ng-brutalism/references/progress.md
+++ b/skills/ng-brutalism/references/progress.md
@@ -1,0 +1,32 @@
+# Progress
+
+A progress bar component with ARIA progressbar semantics. Supports `value`, `max`, and 5 tones for different semantic contexts — from fundraising goals to media playback.
+
+## Import
+```typescript
+import { NbProgress } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `value` | `number` | `0` | Current progress value. Clamped between 0 and max. |
+| `max` | `number` | `100` | Maximum value (100% fill point). |
+| `tone` | `'default' \| 'success' \| 'warning' \| 'danger' \| 'accent'` | `'default'` | Fill color tone. |
+| `label` | `string` | `'Progress'` | ARIA label for the progressbar role. |
+
+## Usage Examples
+
+### Default
+```html
+<nb-progress [value]="68" label="Campaign progress" />
+```
+
+### Tones
+```html
+<nb-progress [value]="60" />
+<nb-progress [value]="80" tone="success" />
+<nb-progress [value]="45" tone="warning" />
+<nb-progress [value]="20" tone="danger" />
+<nb-progress [value]="70" tone="accent" />
+```

--- a/skills/ng-brutalism/references/progress.md
+++ b/skills/ng-brutalism/references/progress.md
@@ -3,26 +3,30 @@
 A progress bar component with ARIA progressbar semantics. Supports `value`, `max`, and 5 tones for different semantic contexts — from fundraising goals to media playback.
 
 ## Import
+
 ```typescript
 import { NbProgress } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `value` | `number` | `0` | Current progress value. Clamped between 0 and max. |
-| `max` | `number` | `100` | Maximum value (100% fill point). |
-| `tone` | `'default' \| 'success' \| 'warning' \| 'danger' \| 'accent'` | `'default'` | Fill color tone. |
-| `label` | `string` | `'Progress'` | ARIA label for the progressbar role. |
+
+| Attribute | Type                                                          | Default      | Description                                        |
+| --------- | ------------------------------------------------------------- | ------------ | -------------------------------------------------- |
+| `value`   | `number`                                                      | `0`          | Current progress value. Clamped between 0 and max. |
+| `max`     | `number`                                                      | `100`        | Maximum value (100% fill point).                   |
+| `tone`    | `'default' \| 'success' \| 'warning' \| 'danger' \| 'accent'` | `'default'`  | Fill color tone.                                   |
+| `label`   | `string`                                                      | `'Progress'` | ARIA label for the progressbar role.               |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <nb-progress [value]="68" label="Campaign progress" />
 ```
 
 ### Tones
+
 ```html
 <nb-progress [value]="60" />
 <nb-progress [value]="80" tone="success" />

--- a/skills/ng-brutalism/references/rating.md
+++ b/skills/ng-brutalism/references/rating.md
@@ -3,25 +3,29 @@
 A read-only star rating display. Accepts a decimal value and rounds to the nearest whole star. Optionally shows a review count. Fully accessible via `role="img"` with an auto-generated `aria-label`.
 
 ## Import
+
 ```typescript
 import { NbRating } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `value` | `number` | `0` | Rating value. Decimal — rounds to nearest whole star. |
-| `max` | `number` | `5` | Total number of stars to render. |
-| `count` | `number \| undefined` | `undefined` | Optional review count shown in parentheses. |
+
+| Attribute | Type                  | Default     | Description                                           |
+| --------- | --------------------- | ----------- | ----------------------------------------------------- |
+| `value`   | `number`              | `0`         | Rating value. Decimal — rounds to nearest whole star. |
+| `max`     | `number`              | `5`         | Total number of stars to render.                      |
+| `count`   | `number \| undefined` | `undefined` | Optional review count shown in parentheses.           |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <nb-rating [value]="4.8" [count]="312" />
 ```
 
 ### Values
+
 ```html
 <nb-rating [value]="5" />
 <nb-rating [value]="4.7" />
@@ -31,12 +35,13 @@ import { NbRating } from '@ng-brutalism/ui';
 ```
 
 ### With Review Count
+
 ```html
-<nb-rating [value]="4.5" [count]="1204" />
-<nb-rating [value]="3.8" [count]="87" />
+<nb-rating [value]="4.5" [count]="1204" /> <nb-rating [value]="3.8" [count]="87" />
 ```
 
 ### Custom Max
+
 ```html
 <nb-rating [value]="7" [max]="10" />
 ```

--- a/skills/ng-brutalism/references/rating.md
+++ b/skills/ng-brutalism/references/rating.md
@@ -1,0 +1,42 @@
+# Rating
+
+A read-only star rating display. Accepts a decimal value and rounds to the nearest whole star. Optionally shows a review count. Fully accessible via `role="img"` with an auto-generated `aria-label`.
+
+## Import
+```typescript
+import { NbRating } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `value` | `number` | `0` | Rating value. Decimal — rounds to nearest whole star. |
+| `max` | `number` | `5` | Total number of stars to render. |
+| `count` | `number \| undefined` | `undefined` | Optional review count shown in parentheses. |
+
+## Usage Examples
+
+### Default
+```html
+<nb-rating [value]="4.8" [count]="312" />
+```
+
+### Values
+```html
+<nb-rating [value]="5" />
+<nb-rating [value]="4.7" />
+<nb-rating [value]="3" />
+<nb-rating [value]="1.2" />
+<nb-rating [value]="0" />
+```
+
+### With Review Count
+```html
+<nb-rating [value]="4.5" [count]="1204" />
+<nb-rating [value]="3.8" [count]="87" />
+```
+
+### Custom Max
+```html
+<nb-rating [value]="7" [max]="10" />
+```

--- a/skills/ng-brutalism/references/section.md
+++ b/skills/ng-brutalism/references/section.md
@@ -3,23 +3,26 @@
 Use `nbSection` for the internal regions of a card — headers, body blocks, and footers. It replaces ad-hoc `border-t-2 px-6 py-6` wrappers with a small declarative primitive for padding, border side, and inline layout.
 
 ## Import
+
 ```typescript
 import { NbSection } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `padding` | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | Inner padding for the section. |
-| `divider` | `'none' \| 'top' \| 'right' \| 'bottom' \| 'left' \| 'block' \| 'inline' \| 'all'` | `'none'` | Which side(s) render a divider line. Uses `--nb-border` and `--nb-border-width`. |
-| `dividerStyle` | `'solid' \| 'dashed' \| 'dotted'` | `'solid'` | Stroke style applied to the active border side(s). |
-| `layout` | `'default' \| 'center' \| 'between'` | `'default'` | `default` keeps block flow, `center` and `between` switch to flex with the matching justify. |
-| `align` | `'stretch' \| 'start' \| 'center' \| 'end'` | `'stretch'` | Cross-axis alignment; only applies when `layout` is `center` or `between`. |
-| `flush` | `boolean` | `false` | Pulls the section out to its parent's edges via negative inline margins. Escape hatch for advanced card layouts. |
+
+| Attribute      | Type                                                                               | Default     | Description                                                                                                      |
+| -------------- | ---------------------------------------------------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------- |
+| `padding`      | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'`                                   | `'md'`      | Inner padding for the section.                                                                                   |
+| `divider`      | `'none' \| 'top' \| 'right' \| 'bottom' \| 'left' \| 'block' \| 'inline' \| 'all'` | `'none'`    | Which side(s) render a divider line. Uses `--nb-border` and `--nb-border-width`.                                 |
+| `dividerStyle` | `'solid' \| 'dashed' \| 'dotted'`                                                  | `'solid'`   | Stroke style applied to the active border side(s).                                                               |
+| `layout`       | `'default' \| 'center' \| 'between'`                                               | `'default'` | `default` keeps block flow, `center` and `between` switch to flex with the matching justify.                     |
+| `align`        | `'stretch' \| 'start' \| 'center' \| 'end'`                                        | `'stretch'` | Cross-axis alignment; only applies when `layout` is `center` or `between`.                                       |
+| `flush`        | `boolean`                                                                          | `false`     | Pulls the section out to its parent's edges via negative inline margins. Escape hatch for advanced card layouts. |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <div nbSurface tone="cream" shadow="hard" radius="lg" clip>
   <div nbSection divider="bottom" padding="lg" layout="between" align="center">
@@ -39,6 +42,7 @@ import { NbSection } from '@ng-brutalism/ui';
 ```
 
 ### Paddings
+
 ```html
 <div nbSection padding="none">...</div>
 <div nbSection padding="xs">...</div>
@@ -49,6 +53,7 @@ import { NbSection } from '@ng-brutalism/ui';
 ```
 
 ### Dividers
+
 ```html
 <div nbSection divider="top">...</div>
 <div nbSection divider="right">...</div>
@@ -60,6 +65,7 @@ import { NbSection } from '@ng-brutalism/ui';
 ```
 
 ### Divider Styles
+
 ```html
 <div nbSection divider="all" dividerStyle="solid">...</div>
 <div nbSection divider="all" dividerStyle="dashed">...</div>
@@ -67,6 +73,7 @@ import { NbSection } from '@ng-brutalism/ui';
 ```
 
 ### Layouts
+
 ```html
 <div nbSection layout="default">...</div>
 <div nbSection layout="center" align="center">...</div>
@@ -74,6 +81,7 @@ import { NbSection } from '@ng-brutalism/ui';
 ```
 
 ### Composition
+
 ```html
 <div nbSurface tone="white" shadow="hard" radius="lg" clip>
   <div nbSection padding="lg" divider="bottom" layout="between" align="center">

--- a/skills/ng-brutalism/references/section.md
+++ b/skills/ng-brutalism/references/section.md
@@ -1,0 +1,93 @@
+# Section
+
+Use `nbSection` for the internal regions of a card — headers, body blocks, and footers. It replaces ad-hoc `border-t-2 px-6 py-6` wrappers with a small declarative primitive for padding, border side, and inline layout.
+
+## Import
+```typescript
+import { NbSection } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `padding` | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | Inner padding for the section. |
+| `divider` | `'none' \| 'top' \| 'right' \| 'bottom' \| 'left' \| 'block' \| 'inline' \| 'all'` | `'none'` | Which side(s) render a divider line. Uses `--nb-border` and `--nb-border-width`. |
+| `dividerStyle` | `'solid' \| 'dashed' \| 'dotted'` | `'solid'` | Stroke style applied to the active border side(s). |
+| `layout` | `'default' \| 'center' \| 'between'` | `'default'` | `default` keeps block flow, `center` and `between` switch to flex with the matching justify. |
+| `align` | `'stretch' \| 'start' \| 'center' \| 'end'` | `'stretch'` | Cross-axis alignment; only applies when `layout` is `center` or `between`. |
+| `flush` | `boolean` | `false` | Pulls the section out to its parent's edges via negative inline margins. Escape hatch for advanced card layouts. |
+
+## Usage Examples
+
+### Default
+```html
+<div nbSurface tone="cream" shadow="hard" radius="lg" clip>
+  <div nbSection divider="bottom" padding="lg" layout="between" align="center">
+    <h2 nbDisplay>Alpha Launch</h2>
+    <span nbChip tone="mint">Active</span>
+  </div>
+
+  <div nbSection padding="lg">
+    <p>Section owns the inner regions of a card.</p>
+  </div>
+
+  <div nbSection divider="top" padding="lg" layout="between" align="center">
+    <span>12 collaborators</span>
+    <button nbButton>Open project</button>
+  </div>
+</div>
+```
+
+### Paddings
+```html
+<div nbSection padding="none">...</div>
+<div nbSection padding="xs">...</div>
+<div nbSection padding="sm">...</div>
+<div nbSection padding="md">...</div>
+<div nbSection padding="lg">...</div>
+<div nbSection padding="xl">...</div>
+```
+
+### Dividers
+```html
+<div nbSection divider="top">...</div>
+<div nbSection divider="right">...</div>
+<div nbSection divider="bottom">...</div>
+<div nbSection divider="left">...</div>
+<div nbSection divider="block">...</div>
+<div nbSection divider="inline">...</div>
+<div nbSection divider="all">...</div>
+```
+
+### Divider Styles
+```html
+<div nbSection divider="all" dividerStyle="solid">...</div>
+<div nbSection divider="all" dividerStyle="dashed">...</div>
+<div nbSection divider="all" dividerStyle="dotted">...</div>
+```
+
+### Layouts
+```html
+<div nbSection layout="default">...</div>
+<div nbSection layout="center" align="center">...</div>
+<div nbSection layout="between" align="center">...</div>
+```
+
+### Composition
+```html
+<div nbSurface tone="white" shadow="hard" radius="lg" clip>
+  <div nbSection padding="lg" divider="bottom" layout="between" align="center">
+    <h2 nbDisplay>Design Sprint</h2>
+    <span nbChip tone="lavender">Annual</span>
+  </div>
+
+  <div nbSection padding="lg">
+    <p>Three weeks of guided sessions and a final brutalist showcase.</p>
+  </div>
+
+  <div nbSection divider="top" padding="lg" layout="between" align="center">
+    <div nbCallout tone="yellow" shadow="hard">$799</div>
+    <button nbButton>Enroll</button>
+  </div>
+</div>
+```

--- a/skills/ng-brutalism/references/select.md
+++ b/skills/ng-brutalism/references/select.md
@@ -1,0 +1,111 @@
+# Select
+
+The neo-brutalist Angular Select component. A brutalist custom dropdown with projected option content, active states, selected checks, and a native select directive for simple forms.
+
+## Import
+```typescript
+import { NbNativeSelect, NbSelect, NbSelectOption } from '@ng-brutalism/ui';
+```
+
+## API Reference
+
+### nb-select (NbSelect)
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `placeholder` | `string` | `'Select an option'` | Text shown when no option is selected. |
+| `value` | `ModelSignal<NbSelectValue \| null>` | `null` | Selected value for two-way binding. |
+| `disabled` | `boolean` | `false` | Disables the trigger and all options. |
+| `aria-label` | `string \| null` | `null` | Accessible label for the trigger. |
+| `aria-labelledby` | `string \| null` | `null` | ID reference for an external label. |
+
+### select[nbSelect] (NbNativeSelect)
+Directive applied to a native `<select>` element to give it the brutal look without the custom listbox behaviour. Detects when nested inside an `<nb-input-group>` and adjusts its border and shadow accordingly. Has no inputs.
+
+## Usage Examples
+
+### Default
+```html
+<nb-select placeholder="Select an option">
+  <nb-select-option value="worldwide" label="Worldwide">
+    Worldwide
+  </nb-select-option>
+  <nb-select-option value="full-time" label="Full-time">
+    Full-time
+  </nb-select-option>
+  <nb-select-option value="part-time" label="Part-time">
+    Part-time
+  </nb-select-option>
+  <nb-select-option value="remote" label="Remote">
+    Remote
+  </nb-select-option>
+</nb-select>
+```
+
+### With Label
+```html
+<div class="grid gap-2">
+  <label nbLabel id="plan-label">Plan</label>
+  <nb-select placeholder="Select a plan" aria-labelledby="plan-label">
+    <nb-select-option value="starter" label="Starter">Starter</nb-select-option>
+    <nb-select-option value="team" label="Team">Team</nb-select-option>
+    <nb-select-option value="enterprise" label="Enterprise">Enterprise</nb-select-option>
+  </nb-select>
+</div>
+```
+
+### With Prefix
+```html
+<div>
+  <label nbLabel id="subject-label" class="mb-2 block">Subject</label>
+  <nb-input-group>
+    <span nbInputPrefix>
+      <!-- Prefix Icon -->
+    </span>
+    <nb-select placeholder="What is this regarding?" aria-labelledby="subject-label">
+      <nb-select-option value="general" label="General Inquiry">General Inquiry</nb-select-option>
+      <nb-select-option value="project" label="Project Proposal">Project Proposal</nb-select-option>
+      <nb-select-option value="bug" label="Bug Report">Bug Report</nb-select-option>
+      <nb-select-option value="other" label="Other">Other</nb-select-option>
+    </nb-select>
+  </nb-input-group>
+</div>
+```
+
+### Custom Option Content
+```html
+<nb-select placeholder="Select location" [value]="'worldwide'">
+  <nb-select-option label="Select location">
+    Select location
+  </nb-select-option>
+  <nb-select-option value="worldwide" label="Worldwide">
+    Worldwide
+  </nb-select-option>
+  <nb-select-option value="north-america" label="North America">
+    North America
+  </nb-select-option>
+  <nb-select-option value="europe" label="Europe">
+    Europe
+  </nb-select-option>
+</nb-select>
+```
+
+### Disabled
+```html
+<nb-select placeholder="Select an option" disabled>
+  <nb-select-option value="one" label="One">One</nb-select-option>
+</nb-select>
+```
+
+### Native Select
+```html
+<select
+  nbSelect
+  class="w-80"
+  aria-label="Favorite accent"
+>
+  <option value="" disabled selected>Favorite accent</option>
+  <option value="mint">Mint</option>
+  <option value="yellow">Yellow</option>
+  <option value="pink">Pink</option>
+</select>
+```

--- a/skills/ng-brutalism/references/select.md
+++ b/skills/ng-brutalism/references/select.md
@@ -3,6 +3,7 @@
 The neo-brutalist Angular Select component. A brutalist custom dropdown with projected option content, active states, selected checks, and a native select directive for simple forms.
 
 ## Import
+
 ```typescript
 import { NbNativeSelect, NbSelect, NbSelectOption } from '@ng-brutalism/ui';
 ```
@@ -10,38 +11,34 @@ import { NbNativeSelect, NbSelect, NbSelectOption } from '@ng-brutalism/ui';
 ## API Reference
 
 ### nb-select (NbSelect)
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `placeholder` | `string` | `'Select an option'` | Text shown when no option is selected. |
-| `value` | `ModelSignal<NbSelectValue \| null>` | `null` | Selected value for two-way binding. |
-| `disabled` | `boolean` | `false` | Disables the trigger and all options. |
-| `aria-label` | `string \| null` | `null` | Accessible label for the trigger. |
-| `aria-labelledby` | `string \| null` | `null` | ID reference for an external label. |
+
+| Attribute         | Type                                 | Default              | Description                            |
+| ----------------- | ------------------------------------ | -------------------- | -------------------------------------- |
+| `placeholder`     | `string`                             | `'Select an option'` | Text shown when no option is selected. |
+| `value`           | `ModelSignal<NbSelectValue \| null>` | `null`               | Selected value for two-way binding.    |
+| `disabled`        | `boolean`                            | `false`              | Disables the trigger and all options.  |
+| `aria-label`      | `string \| null`                     | `null`               | Accessible label for the trigger.      |
+| `aria-labelledby` | `string \| null`                     | `null`               | ID reference for an external label.    |
 
 ### select[nbSelect] (NbNativeSelect)
+
 Directive applied to a native `<select>` element to give it the brutal look without the custom listbox behaviour. Detects when nested inside an `<nb-input-group>` and adjusts its border and shadow accordingly. Has no inputs.
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <nb-select placeholder="Select an option">
-  <nb-select-option value="worldwide" label="Worldwide">
-    Worldwide
-  </nb-select-option>
-  <nb-select-option value="full-time" label="Full-time">
-    Full-time
-  </nb-select-option>
-  <nb-select-option value="part-time" label="Part-time">
-    Part-time
-  </nb-select-option>
-  <nb-select-option value="remote" label="Remote">
-    Remote
-  </nb-select-option>
+  <nb-select-option value="worldwide" label="Worldwide"> Worldwide </nb-select-option>
+  <nb-select-option value="full-time" label="Full-time"> Full-time </nb-select-option>
+  <nb-select-option value="part-time" label="Part-time"> Part-time </nb-select-option>
+  <nb-select-option value="remote" label="Remote"> Remote </nb-select-option>
 </nb-select>
 ```
 
 ### With Label
+
 ```html
 <div class="grid gap-2">
   <label nbLabel id="plan-label">Plan</label>
@@ -54,6 +51,7 @@ Directive applied to a native `<select>` element to give it the brutal look with
 ```
 
 ### With Prefix
+
 ```html
 <div>
   <label nbLabel id="subject-label" class="mb-2 block">Subject</label>
@@ -72,24 +70,18 @@ Directive applied to a native `<select>` element to give it the brutal look with
 ```
 
 ### Custom Option Content
+
 ```html
 <nb-select placeholder="Select location" [value]="'worldwide'">
-  <nb-select-option label="Select location">
-    Select location
-  </nb-select-option>
-  <nb-select-option value="worldwide" label="Worldwide">
-    Worldwide
-  </nb-select-option>
-  <nb-select-option value="north-america" label="North America">
-    North America
-  </nb-select-option>
-  <nb-select-option value="europe" label="Europe">
-    Europe
-  </nb-select-option>
+  <nb-select-option label="Select location"> Select location </nb-select-option>
+  <nb-select-option value="worldwide" label="Worldwide"> Worldwide </nb-select-option>
+  <nb-select-option value="north-america" label="North America"> North America </nb-select-option>
+  <nb-select-option value="europe" label="Europe"> Europe </nb-select-option>
 </nb-select>
 ```
 
 ### Disabled
+
 ```html
 <nb-select placeholder="Select an option" disabled>
   <nb-select-option value="one" label="One">One</nb-select-option>
@@ -97,12 +89,9 @@ Directive applied to a native `<select>` element to give it the brutal look with
 ```
 
 ### Native Select
+
 ```html
-<select
-  nbSelect
-  class="w-80"
-  aria-label="Favorite accent"
->
+<select nbSelect class="w-80" aria-label="Favorite accent">
   <option value="" disabled selected>Favorite accent</option>
   <option value="mint">Mint</option>
   <option value="yellow">Yellow</option>

--- a/skills/ng-brutalism/references/separator.md
+++ b/skills/ng-brutalism/references/separator.md
@@ -1,0 +1,48 @@
+# Separator
+
+A directive on `<hr>` for visual section dividers. Supports horizontal and vertical orientations with solid, dashed, and thick variants — a structural staple in every brutalist card layout.
+
+## Import
+```typescript
+import { NbSeparator } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Direction of the divider line. |
+| `variant` | `'solid' \| 'dashed' \| 'thick'` | `'solid'` | Line style. `thick` renders a 4 px border. |
+
+## Usage Examples
+
+### Default
+```html
+<p class="font-bold">Section A</p>
+<hr nbSeparator />
+<p class="font-bold">Section B</p>
+```
+
+### Variants
+```html
+<hr nbSeparator />
+<hr nbSeparator variant="dashed" />
+<hr nbSeparator variant="thick" />
+```
+
+### Vertical Orientation
+```html
+<div class="flex h-16 items-center gap-4">
+  <span>Angular</span>
+  <hr nbSeparator orientation="vertical" />
+  <span>Brutalism</span>
+  <hr nbSeparator orientation="vertical" variant="dashed" />
+  <span>v0.2</span>
+</div>
+```
+
+### Custom Color
+```html
+<hr nbSeparator style="--nb-separator-color: #ff90e8" />
+<hr nbSeparator variant="thick" style="--nb-separator-color: #8ae9ff" />
+<hr nbSeparator variant="dashed" style="--nb-separator-color: #c8a2ff" />
+```

--- a/skills/ng-brutalism/references/separator.md
+++ b/skills/ng-brutalism/references/separator.md
@@ -3,19 +3,22 @@
 A directive on `<hr>` for visual section dividers. Supports horizontal and vertical orientations with solid, dashed, and thick variants — a structural staple in every brutalist card layout.
 
 ## Import
+
 ```typescript
 import { NbSeparator } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Direction of the divider line. |
-| `variant` | `'solid' \| 'dashed' \| 'thick'` | `'solid'` | Line style. `thick` renders a 4 px border. |
+
+| Attribute     | Type                             | Default        | Description                                |
+| ------------- | -------------------------------- | -------------- | ------------------------------------------ |
+| `orientation` | `'horizontal' \| 'vertical'`     | `'horizontal'` | Direction of the divider line.             |
+| `variant`     | `'solid' \| 'dashed' \| 'thick'` | `'solid'`      | Line style. `thick` renders a 4 px border. |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <p class="font-bold">Section A</p>
 <hr nbSeparator />
@@ -23,6 +26,7 @@ import { NbSeparator } from '@ng-brutalism/ui';
 ```
 
 ### Variants
+
 ```html
 <hr nbSeparator />
 <hr nbSeparator variant="dashed" />
@@ -30,6 +34,7 @@ import { NbSeparator } from '@ng-brutalism/ui';
 ```
 
 ### Vertical Orientation
+
 ```html
 <div class="flex h-16 items-center gap-4">
   <span>Angular</span>
@@ -41,6 +46,7 @@ import { NbSeparator } from '@ng-brutalism/ui';
 ```
 
 ### Custom Color
+
 ```html
 <hr nbSeparator style="--nb-separator-color: #ff90e8" />
 <hr nbSeparator variant="thick" style="--nb-separator-color: #8ae9ff" />

--- a/skills/ng-brutalism/references/split-layouts.md
+++ b/skills/ng-brutalism/references/split-layouts.md
@@ -1,0 +1,95 @@
+# Split Layouts
+
+`nbSplit` creates two-region layouts — hero sections, media/content pairs, sidebar layouts, pricing sections, and profile cards. It replaces repeated grid boilerplate with a single, responsive primitive.
+
+## Import
+```typescript
+import { NbSplit } from '@ng-brutalism/ui';
+```
+
+## API Reference
+
+### Key Inputs
+| Input | Description |
+|---|---|
+| `ratio` | Column proportions — `1:1`, `2:1`, `3:1`, `1:2`, `1:3`, `fill:auto`, `auto:fill` |
+| `collapse` | Breakpoint where columns stack — `none`, `sm`, `md`, `lg` |
+| `gap` | Space between the two columns — `xs`, `sm`, `md`, `lg`, `xl` |
+| `align` | Cross-axis alignment — `start`, `center`, `end`, `stretch` |
+| `separator` | Vertical divider — `none`, `solid`, `dashed`, `thick` |
+| `padding` | Inner padding on the split container — `xs`, `sm`, `md`, `lg`, `xl` |
+
+## Usage Examples
+
+### Default Ratios
+```html
+<!-- Equal columns -->
+<section nbSplit ratio="1:1" gap="lg" collapse="md">...</section>
+
+<!-- Wide main + narrow aside (2:1) -->
+<section nbSplit ratio="2:1" gap="lg" collapse="md">...</section>
+
+<!-- Very wide main + narrow panel (3:1) -->
+<section nbSplit ratio="3:1" gap="xl" collapse="lg">...</section>
+
+<!-- Fixed aside, flexible main -->
+<section nbSplit ratio="fill:auto" gap="lg" collapse="md">...</section>
+```
+
+### Hero Split
+```html
+<section nbSplit ratio="2:1" gap="lg" collapse="md" align="stretch">
+  <article nbSurface tone="yellow" padding="xl" radius="xl"
+           shadow="hard" border="strong">
+    <div nbStack gap="md">
+      <h1 nbDisplay size="lg">Build loud.<br />Stay sharp.</h1>
+      <p nbText size="lg">
+        Composition primitives for brutalist Angular UIs.
+      </p>
+      <div nbCluster gap="sm">
+        <button nbButton tone="black">Get started</button>
+        <button nbButton tone="white">Browse components</button>
+      </div>
+    </div>
+  </article>
+
+  <aside nbStack gap="md">
+    <div nbSurface tone="pink" padding="lg" radius="lg"
+         shadow="hard" border="strong">
+      <p nbText weight="bold">Composition primitives</p>
+    </div>
+    <div nbSurface tone="mint" padding="lg" radius="lg"
+         shadow="hard" border="strong">
+      <p nbText weight="bold">Token-driven styling</p>
+    </div>
+    <div nbSurface tone="lavender" padding="lg" radius="lg"
+         shadow="hard" border="strong">
+      <p nbText weight="bold">Angular-first APIs</p>
+    </div>
+  </aside>
+</section>
+```
+
+### Media / Content Split
+```html
+<section nbSplit ratio="1:1" gap="lg" collapse="md">
+  <div nbSurface tone="cream" padding="lg" radius="xl"
+       shadow="hard" border="strong"
+       class="grid aspect-video place-items-center text-5xl font-black">
+    01
+  </div>
+
+  <div nbStack gap="md">
+    <h2 nbDisplay size="sm" underline="bar" underlineGap="xs" class="inline-flex flex-col items-start" style="--nb-underline-width: 45%">Recipe card</h2>
+    <p nbText tone="muted">
+      Use split layouts for visual/content compositions.
+    </p>
+    <div nbCluster gap="xs">
+      <span nbChip tone="yellow">30 min</span>
+      <span nbChip tone="mint">Easy</span>
+      <span nbChip tone="pink">Vegan</span>
+    </div>
+    <button nbButton tone="black" size="sm">View recipe</button>
+  </div>
+</section>
+```

--- a/skills/ng-brutalism/references/split-layouts.md
+++ b/skills/ng-brutalism/references/split-layouts.md
@@ -3,6 +3,7 @@
 `nbSplit` creates two-region layouts — hero sections, media/content pairs, sidebar layouts, pricing sections, and profile cards. It replaces repeated grid boilerplate with a single, responsive primitive.
 
 ## Import
+
 ```typescript
 import { NbSplit } from '@ng-brutalism/ui';
 ```
@@ -10,18 +11,20 @@ import { NbSplit } from '@ng-brutalism/ui';
 ## API Reference
 
 ### Key Inputs
-| Input | Description |
-|---|---|
-| `ratio` | Column proportions — `1:1`, `2:1`, `3:1`, `1:2`, `1:3`, `fill:auto`, `auto:fill` |
-| `collapse` | Breakpoint where columns stack — `none`, `sm`, `md`, `lg` |
-| `gap` | Space between the two columns — `xs`, `sm`, `md`, `lg`, `xl` |
-| `align` | Cross-axis alignment — `start`, `center`, `end`, `stretch` |
-| `separator` | Vertical divider — `none`, `solid`, `dashed`, `thick` |
-| `padding` | Inner padding on the split container — `xs`, `sm`, `md`, `lg`, `xl` |
+
+| Input       | Description                                                                      |
+| ----------- | -------------------------------------------------------------------------------- |
+| `ratio`     | Column proportions — `1:1`, `2:1`, `3:1`, `1:2`, `1:3`, `fill:auto`, `auto:fill` |
+| `collapse`  | Breakpoint where columns stack — `none`, `sm`, `md`, `lg`                        |
+| `gap`       | Space between the two columns — `xs`, `sm`, `md`, `lg`, `xl`                     |
+| `align`     | Cross-axis alignment — `start`, `center`, `end`, `stretch`                       |
+| `separator` | Vertical divider — `none`, `solid`, `dashed`, `thick`                            |
+| `padding`   | Inner padding on the split container — `xs`, `sm`, `md`, `lg`, `xl`              |
 
 ## Usage Examples
 
 ### Default Ratios
+
 ```html
 <!-- Equal columns -->
 <section nbSplit ratio="1:1" gap="lg" collapse="md">...</section>
@@ -37,15 +40,13 @@ import { NbSplit } from '@ng-brutalism/ui';
 ```
 
 ### Hero Split
+
 ```html
 <section nbSplit ratio="2:1" gap="lg" collapse="md" align="stretch">
-  <article nbSurface tone="yellow" padding="xl" radius="xl"
-           shadow="hard" border="strong">
+  <article nbSurface tone="yellow" padding="xl" radius="xl" shadow="hard" border="strong">
     <div nbStack gap="md">
       <h1 nbDisplay size="lg">Build loud.<br />Stay sharp.</h1>
-      <p nbText size="lg">
-        Composition primitives for brutalist Angular UIs.
-      </p>
+      <p nbText size="lg">Composition primitives for brutalist Angular UIs.</p>
       <div nbCluster gap="sm">
         <button nbButton tone="black">Get started</button>
         <button nbButton tone="white">Browse components</button>
@@ -54,16 +55,13 @@ import { NbSplit } from '@ng-brutalism/ui';
   </article>
 
   <aside nbStack gap="md">
-    <div nbSurface tone="pink" padding="lg" radius="lg"
-         shadow="hard" border="strong">
+    <div nbSurface tone="pink" padding="lg" radius="lg" shadow="hard" border="strong">
       <p nbText weight="bold">Composition primitives</p>
     </div>
-    <div nbSurface tone="mint" padding="lg" radius="lg"
-         shadow="hard" border="strong">
+    <div nbSurface tone="mint" padding="lg" radius="lg" shadow="hard" border="strong">
       <p nbText weight="bold">Token-driven styling</p>
     </div>
-    <div nbSurface tone="lavender" padding="lg" radius="lg"
-         shadow="hard" border="strong">
+    <div nbSurface tone="lavender" padding="lg" radius="lg" shadow="hard" border="strong">
       <p nbText weight="bold">Angular-first APIs</p>
     </div>
   </aside>
@@ -71,19 +69,14 @@ import { NbSplit } from '@ng-brutalism/ui';
 ```
 
 ### Media / Content Split
+
 ```html
 <section nbSplit ratio="1:1" gap="lg" collapse="md">
-  <div nbSurface tone="cream" padding="lg" radius="xl"
-       shadow="hard" border="strong"
-       class="grid aspect-video place-items-center text-5xl font-black">
-    01
-  </div>
+  <div nbSurface tone="cream" padding="lg" radius="xl" shadow="hard" border="strong" class="grid aspect-video place-items-center text-5xl font-black">01</div>
 
   <div nbStack gap="md">
     <h2 nbDisplay size="sm" underline="bar" underlineGap="xs" class="inline-flex flex-col items-start" style="--nb-underline-width: 45%">Recipe card</h2>
-    <p nbText tone="muted">
-      Use split layouts for visual/content compositions.
-    </p>
+    <p nbText tone="muted">Use split layouts for visual/content compositions.</p>
     <div nbCluster gap="xs">
       <span nbChip tone="yellow">30 min</span>
       <span nbChip tone="mint">Easy</span>

--- a/skills/ng-brutalism/references/split.md
+++ b/skills/ng-brutalism/references/split.md
@@ -3,23 +3,26 @@
 Use `nbSplit` for two-column main-and-aside compositions. It replaces custom grid column strings with ratio, gap, padding, alignment, and responsive collapse inputs.
 
 ## Import
+
 ```typescript
 import { NbSplit } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `ratio` | `'1:1' \| '2:1' \| '3:1' \| '1:2' \| '1:3' \| 'fill:auto' \| 'auto:fill'` | `'1:1'` | Column relationship between main and aside content. |
-| `gap` | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| '2xl'` | `'lg'` | Spacing between the two split regions. |
-| `padding` | `'none' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'none'` | Inner padding for the split container. |
-| `collapse` | `'none' \| 'sm' \| 'md' \| 'lg'` | `'md'` | Breakpoint where the layout switches from stacked to two columns. |
-| `align` | `'start' \| 'center' \| 'end' \| 'stretch'` | `'stretch'` | Cross-axis alignment for the two regions. |
-| `separator` | `'none' \| 'solid' \| 'dashed' \| 'thick'` | `'none'` | Inline separator between the two regions. Use with a non-zero gap. |
+
+| Attribute   | Type                                                                      | Default     | Description                                                        |
+| ----------- | ------------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------ |
+| `ratio`     | `'1:1' \| '2:1' \| '3:1' \| '1:2' \| '1:3' \| 'fill:auto' \| 'auto:fill'` | `'1:1'`     | Column relationship between main and aside content.                |
+| `gap`       | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| '2xl'`                 | `'lg'`      | Spacing between the two split regions.                             |
+| `padding`   | `'none' \| 'sm' \| 'md' \| 'lg' \| 'xl'`                                  | `'none'`    | Inner padding for the split container.                             |
+| `collapse`  | `'none' \| 'sm' \| 'md' \| 'lg'`                                          | `'md'`      | Breakpoint where the layout switches from stacked to two columns.  |
+| `align`     | `'start' \| 'center' \| 'end' \| 'stretch'`                               | `'stretch'` | Cross-axis alignment for the two regions.                          |
+| `separator` | `'none' \| 'solid' \| 'dashed' \| 'thick'`                                | `'none'`    | Inline separator between the two regions. Use with a non-zero gap. |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <div nbSplit ratio="2:1" gap="xl" padding="lg">
   <div nbStack gap="md">
@@ -35,6 +38,7 @@ import { NbSplit } from '@ng-brutalism/ui';
 ```
 
 ### Ratios
+
 ```html
 <div nbSplit ratio="1:1">...</div>
 <div nbSplit ratio="2:1">...</div>
@@ -48,6 +52,7 @@ import { NbSplit } from '@ng-brutalism/ui';
 ```
 
 ### Spacing
+
 ```html
 <div nbSplit gap="xl" padding="lg">
   <div>Main</div>
@@ -56,6 +61,7 @@ import { NbSplit } from '@ng-brutalism/ui';
 ```
 
 ### Collapse
+
 ```html
 <div nbSplit collapse="none">...</div>
 <div nbSplit collapse="sm">...</div>
@@ -64,6 +70,7 @@ import { NbSplit } from '@ng-brutalism/ui';
 ```
 
 ### Alignment
+
 ```html
 <div nbSplit align="start">...</div>
 <div nbSplit align="center">...</div>
@@ -72,6 +79,7 @@ import { NbSplit } from '@ng-brutalism/ui';
 ```
 
 ### Separators
+
 ```html
 <div nbSplit ratio="2:1" gap="lg" separator="solid">
   <div>Main</div>
@@ -90,6 +98,7 @@ import { NbSplit } from '@ng-brutalism/ui';
 ```
 
 ### Composition
+
 ```html
 <div nbSplit ratio="2:1" gap="xl" padding="lg" collapse="md">
   <div nbStack gap="lg">

--- a/skills/ng-brutalism/references/split.md
+++ b/skills/ng-brutalism/references/split.md
@@ -1,0 +1,103 @@
+# Split
+
+Use `nbSplit` for two-column main-and-aside compositions. It replaces custom grid column strings with ratio, gap, padding, alignment, and responsive collapse inputs.
+
+## Import
+```typescript
+import { NbSplit } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `ratio` | `'1:1' \| '2:1' \| '3:1' \| '1:2' \| '1:3' \| 'fill:auto' \| 'auto:fill'` | `'1:1'` | Column relationship between main and aside content. |
+| `gap` | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| '2xl'` | `'lg'` | Spacing between the two split regions. |
+| `padding` | `'none' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'none'` | Inner padding for the split container. |
+| `collapse` | `'none' \| 'sm' \| 'md' \| 'lg'` | `'md'` | Breakpoint where the layout switches from stacked to two columns. |
+| `align` | `'start' \| 'center' \| 'end' \| 'stretch'` | `'stretch'` | Cross-axis alignment for the two regions. |
+| `separator` | `'none' \| 'solid' \| 'dashed' \| 'thick'` | `'none'` | Inline separator between the two regions. Use with a non-zero gap. |
+
+## Usage Examples
+
+### Default
+```html
+<div nbSplit ratio="2:1" gap="xl" padding="lg">
+  <div nbStack gap="md">
+    <h2 nbDisplay>Tokyo City Escape</h2>
+    <p>Main content</p>
+  </div>
+
+  <div nbStack gap="md" align="start">
+    <span>$799</span>
+    <button nbButton>Book Trip</button>
+  </div>
+</div>
+```
+
+### Ratios
+```html
+<div nbSplit ratio="1:1">...</div>
+<div nbSplit ratio="2:1">...</div>
+<div nbSplit ratio="3:1">...</div>
+<div nbSplit ratio="1:2">...</div>
+<div nbSplit ratio="1:3">...</div>
+<!-- first column fills, second hugs its content -->
+<div nbSplit ratio="fill:auto">...</div>
+<!-- first column hugs its content, second fills -->
+<div nbSplit ratio="auto:fill">...</div>
+```
+
+### Spacing
+```html
+<div nbSplit gap="xl" padding="lg">
+  <div>Main</div>
+  <div>Aside</div>
+</div>
+```
+
+### Collapse
+```html
+<div nbSplit collapse="none">...</div>
+<div nbSplit collapse="sm">...</div>
+<div nbSplit collapse="md">...</div>
+<div nbSplit collapse="lg">...</div>
+```
+
+### Alignment
+```html
+<div nbSplit align="start">...</div>
+<div nbSplit align="center">...</div>
+<div nbSplit align="end">...</div>
+<div nbSplit align="stretch">...</div>
+```
+
+### Separators
+```html
+<div nbSplit ratio="2:1" gap="lg" separator="solid">
+  <div>Main</div>
+  <div>Aside</div>
+</div>
+
+<div nbSplit ratio="2:1" gap="lg" separator="dashed">
+  <div>Main</div>
+  <div>Aside</div>
+</div>
+
+<div nbSplit ratio="2:1" gap="lg" separator="thick">
+  <div>Main</div>
+  <div>Aside</div>
+</div>
+```
+
+### Composition
+```html
+<div nbSplit ratio="2:1" gap="xl" padding="lg" collapse="md">
+  <div nbStack gap="lg">
+    <!-- Main content -->
+  </div>
+
+  <div nbStack gap="md" align="start">
+    <!-- Aside content -->
+  </div>
+</div>
+```

--- a/skills/ng-brutalism/references/stack-and-cluster.md
+++ b/skills/ng-brutalism/references/stack-and-cluster.md
@@ -1,0 +1,70 @@
+# Stack & Cluster
+
+`nbStack` is the default primitive for vertical rhythm. `nbCluster` is the default primitive for inline groups that may wrap. Use them everywhere instead of manually wiring up flex utilities.
+
+## Import
+```typescript
+import { NbStack, NbCluster } from '@ng-brutalism/ui';
+```
+
+## API Reference
+### nbStack
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `gap` | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | - | Vertical spacing |
+| `align` | `'stretch' \| 'start' \| 'center' \| 'end'` | - | Cross-axis alignment |
+| `justify` | `'start' \| 'center' \| 'end' \| 'between'` | - | Main-axis alignment |
+| `separator` | `'none' \| 'solid' \| 'dashed' \| 'thick'` | `'none'` | Divider between children |
+
+### nbCluster
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `gap` | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | - | Horizontal spacing |
+| `align` | `'start' \| 'center' \| 'end' \| 'baseline' \| 'stretch'` | - | Cross-axis alignment |
+| `justify` | `'start' \| 'center' \| 'end' \| 'between'` | - | Main-axis alignment |
+| `wrap` | `'wrap' \| 'nowrap'` | `'wrap'` | Wrapping behavior |
+
+## Usage Examples
+
+### Stack — vertical card content
+```html
+<div nbStack gap="md">
+  <h2 nbDisplay size="sm" underline="bar" underlineGap="xs" class="inline-flex flex-col items-start" style="--nb-underline-width: 80%">Open role</h2>
+  <span nbChip tone="mint">Hiring now</span>
+  <p nbText>Compose content vertically with predictable spacing.</p>
+  <button nbButton tone="yellow" size="lg">Apply now</button>
+</div>
+```
+
+### Cluster — chip group
+```html
+<div nbCluster gap="xs">
+  <span nbChip tone="yellow">Angular</span>
+  <span nbChip tone="mint">Signals</span>
+  <span nbChip tone="pink">Zoneless</span>
+  <span nbChip tone="lavender">TypeScript</span>
+</div>
+```
+
+### Combined inside a Surface
+```html
+<article nbSurface tone="cream" padding="lg" radius="xl" shadow="hard" border="strong">
+  <div nbStack gap="lg">
+    <div nbStack gap="xs">
+      <h2 nbDisplay size="sm" underline="bar" underlineGap="xs" class="inline-flex flex-col items-start" style="--nb-underline-width: 45%">Senior Angular Engineer</h2>
+      <p nbText tone="muted">Build loud UI primitives.</p>
+    </div>
+
+    <div nbCluster gap="xs">
+      <span nbChip tone="yellow">Remote</span>
+      <span nbChip tone="mint">Full-time</span>
+      <span nbChip tone="pink">Urgent</span>
+    </div>
+
+    <div nbCluster gap="sm">
+      <button nbButton tone="black">Apply</button>
+      <button nbButton tone="white">Save</button>
+    </div>
+  </div>
+</article>
+```

--- a/skills/ng-brutalism/references/stack-and-cluster.md
+++ b/skills/ng-brutalism/references/stack-and-cluster.md
@@ -3,30 +3,35 @@
 `nbStack` is the default primitive for vertical rhythm. `nbCluster` is the default primitive for inline groups that may wrap. Use them everywhere instead of manually wiring up flex utilities.
 
 ## Import
+
 ```typescript
 import { NbStack, NbCluster } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
+
 ### nbStack
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `gap` | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | - | Vertical spacing |
-| `align` | `'stretch' \| 'start' \| 'center' \| 'end'` | - | Cross-axis alignment |
-| `justify` | `'start' \| 'center' \| 'end' \| 'between'` | - | Main-axis alignment |
-| `separator` | `'none' \| 'solid' \| 'dashed' \| 'thick'` | `'none'` | Divider between children |
+
+| Attribute   | Type                                        | Default  | Description              |
+| ----------- | ------------------------------------------- | -------- | ------------------------ |
+| `gap`       | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'`      | -        | Vertical spacing         |
+| `align`     | `'stretch' \| 'start' \| 'center' \| 'end'` | -        | Cross-axis alignment     |
+| `justify`   | `'start' \| 'center' \| 'end' \| 'between'` | -        | Main-axis alignment      |
+| `separator` | `'none' \| 'solid' \| 'dashed' \| 'thick'`  | `'none'` | Divider between children |
 
 ### nbCluster
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `gap` | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | - | Horizontal spacing |
-| `align` | `'start' \| 'center' \| 'end' \| 'baseline' \| 'stretch'` | - | Cross-axis alignment |
-| `justify` | `'start' \| 'center' \| 'end' \| 'between'` | - | Main-axis alignment |
-| `wrap` | `'wrap' \| 'nowrap'` | `'wrap'` | Wrapping behavior |
+
+| Attribute | Type                                                      | Default  | Description          |
+| --------- | --------------------------------------------------------- | -------- | -------------------- |
+| `gap`     | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'`                    | -        | Horizontal spacing   |
+| `align`   | `'start' \| 'center' \| 'end' \| 'baseline' \| 'stretch'` | -        | Cross-axis alignment |
+| `justify` | `'start' \| 'center' \| 'end' \| 'between'`               | -        | Main-axis alignment  |
+| `wrap`    | `'wrap' \| 'nowrap'`                                      | `'wrap'` | Wrapping behavior    |
 
 ## Usage Examples
 
 ### Stack — vertical card content
+
 ```html
 <div nbStack gap="md">
   <h2 nbDisplay size="sm" underline="bar" underlineGap="xs" class="inline-flex flex-col items-start" style="--nb-underline-width: 80%">Open role</h2>
@@ -37,6 +42,7 @@ import { NbStack, NbCluster } from '@ng-brutalism/ui';
 ```
 
 ### Cluster — chip group
+
 ```html
 <div nbCluster gap="xs">
   <span nbChip tone="yellow">Angular</span>
@@ -47,6 +53,7 @@ import { NbStack, NbCluster } from '@ng-brutalism/ui';
 ```
 
 ### Combined inside a Surface
+
 ```html
 <article nbSurface tone="cream" padding="lg" radius="xl" shadow="hard" border="strong">
   <div nbStack gap="lg">

--- a/skills/ng-brutalism/references/stack.md
+++ b/skills/ng-brutalism/references/stack.md
@@ -3,35 +3,36 @@
 Use `nbStack` whenever children should flow vertically with consistent spacing. It turns raw `flex flex-col gap-*` layout boilerplate into a small declarative primitive for vertical rhythm.
 
 ## Import
+
 ```typescript
 import { NbStack } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `gap` | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| '2xl'` | `'md'` | Vertical spacing between stack children. |
-| `align` | `'stretch' \| 'start' \| 'center' \| 'end'` | `'stretch'` | Cross-axis alignment for the stack children. |
-| `justify` | `'start' \| 'center' \| 'end' \| 'between'` | `'start'` | Main-axis distribution when the stack has extra height. |
-| `separator` | `'none' \| 'solid' \| 'dashed' \| 'thick'` | `'none'` | Optional border between adjacent children. |
+
+| Attribute   | Type                                                      | Default     | Description                                             |
+| ----------- | --------------------------------------------------------- | ----------- | ------------------------------------------------------- |
+| `gap`       | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| '2xl'` | `'md'`      | Vertical spacing between stack children.                |
+| `align`     | `'stretch' \| 'start' \| 'center' \| 'end'`               | `'stretch'` | Cross-axis alignment for the stack children.            |
+| `justify`   | `'start' \| 'center' \| 'end' \| 'between'`               | `'start'`   | Main-axis distribution when the stack has extra height. |
+| `separator` | `'none' \| 'solid' \| 'dashed' \| 'thick'`                | `'none'`    | Optional border between adjacent children.              |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <div nbStack gap="lg">
   <h2 nbDisplay>Build loud.</h2>
 
-  <p>
-    Stack gives you brutalist vertical rhythm without repeating flex and gap
-    classes everywhere.
-  </p>
+  <p>Stack gives you brutalist vertical rhythm without repeating flex and gap classes everywhere.</p>
 
   <button nbButton>Stay sharp</button>
 </div>
 ```
 
 ### Gaps
+
 ```html
 <div nbStack gap="none">...</div>
 <div nbStack gap="xs">...</div>
@@ -43,6 +44,7 @@ import { NbStack } from '@ng-brutalism/ui';
 ```
 
 ### Alignment
+
 ```html
 <div nbStack gap="sm" align="stretch">...</div>
 <div nbStack gap="sm" align="start">...</div>
@@ -51,6 +53,7 @@ import { NbStack } from '@ng-brutalism/ui';
 ```
 
 ### Justification
+
 ```html
 <div nbStack justify="start" class="h-56">...</div>
 <div nbStack justify="center" class="h-56">...</div>
@@ -59,6 +62,7 @@ import { NbStack } from '@ng-brutalism/ui';
 ```
 
 ### Separators
+
 ```html
 <div nbStack gap="md" separator="dashed">
   <nb-media-item icon="/icons/location.svg" title="Central Locations" />
@@ -68,12 +72,7 @@ import { NbStack } from '@ng-brutalism/ui';
 ```
 
 ### Responsive Gap
+
 ```html
-<div
-  nbStack
-  gap="md"
-  class="md:[--nb-stack-gap:1.5rem]"
->
-  ...
-</div>
+<div nbStack gap="md" class="md:[--nb-stack-gap:1.5rem]">...</div>
 ```

--- a/skills/ng-brutalism/references/stack.md
+++ b/skills/ng-brutalism/references/stack.md
@@ -1,0 +1,79 @@
+# Stack
+
+Use `nbStack` whenever children should flow vertically with consistent spacing. It turns raw `flex flex-col gap-*` layout boilerplate into a small declarative primitive for vertical rhythm.
+
+## Import
+```typescript
+import { NbStack } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `gap` | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| '2xl'` | `'md'` | Vertical spacing between stack children. |
+| `align` | `'stretch' \| 'start' \| 'center' \| 'end'` | `'stretch'` | Cross-axis alignment for the stack children. |
+| `justify` | `'start' \| 'center' \| 'end' \| 'between'` | `'start'` | Main-axis distribution when the stack has extra height. |
+| `separator` | `'none' \| 'solid' \| 'dashed' \| 'thick'` | `'none'` | Optional border between adjacent children. |
+
+## Usage Examples
+
+### Default
+```html
+<div nbStack gap="lg">
+  <h2 nbDisplay>Build loud.</h2>
+
+  <p>
+    Stack gives you brutalist vertical rhythm without repeating flex and gap
+    classes everywhere.
+  </p>
+
+  <button nbButton>Stay sharp</button>
+</div>
+```
+
+### Gaps
+```html
+<div nbStack gap="none">...</div>
+<div nbStack gap="xs">...</div>
+<div nbStack gap="sm">...</div>
+<div nbStack gap="md">...</div>
+<div nbStack gap="lg">...</div>
+<div nbStack gap="xl">...</div>
+<div nbStack gap="2xl">...</div>
+```
+
+### Alignment
+```html
+<div nbStack gap="sm" align="stretch">...</div>
+<div nbStack gap="sm" align="start">...</div>
+<div nbStack gap="sm" align="center">...</div>
+<div nbStack gap="sm" align="end">...</div>
+```
+
+### Justification
+```html
+<div nbStack justify="start" class="h-56">...</div>
+<div nbStack justify="center" class="h-56">...</div>
+<div nbStack justify="end" class="h-56">...</div>
+<div nbStack justify="between" class="h-56">...</div>
+```
+
+### Separators
+```html
+<div nbStack gap="md" separator="dashed">
+  <nb-media-item icon="/icons/location.svg" title="Central Locations" />
+  <nb-media-item icon="/icons/camera.svg" title="Guided Experiences" />
+  <nb-media-item icon="/icons/support.svg" title="24/7 Support" />
+</div>
+```
+
+### Responsive Gap
+```html
+<div
+  nbStack
+  gap="md"
+  class="md:[--nb-stack-gap:1.5rem]"
+>
+  ...
+</div>
+```

--- a/skills/ng-brutalism/references/stat.md
+++ b/skills/ng-brutalism/references/stat.md
@@ -1,0 +1,37 @@
+# Stat
+
+A compact value + label display for surfacing metrics, prices, counts, and scores. Used throughout brutalist card designs to anchor key numbers with maximum visual weight.
+
+## Import
+```typescript
+import { NbStat } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `value` | `string` | *required* | The primary metric value displayed prominently. |
+| `label` | `string` | *required* | Descriptive label rendered below (or beside) the value. |
+| `direction` | `'column' \| 'row'` | `'column'` | Stacks value + label vertically or horizontally. |
+
+## Usage Examples
+
+### Default
+```html
+<nb-stat value="$29" label="per month" />
+<nb-stat value="4.8★" label="rating" />
+<nb-stat value="142" label="backed" />
+```
+
+### With icon
+```html
+<nb-stat value="4.9" label="rating">
+  <span slot="icon" aria-hidden="true">★</span>
+</nb-stat>
+```
+
+### Row direction
+```html
+<nb-stat value="98%" label="satisfaction" direction="row" />
+<nb-stat value="12K" label="downloads" direction="row" />
+```

--- a/skills/ng-brutalism/references/stat.md
+++ b/skills/ng-brutalism/references/stat.md
@@ -3,20 +3,23 @@
 A compact value + label display for surfacing metrics, prices, counts, and scores. Used throughout brutalist card designs to anchor key numbers with maximum visual weight.
 
 ## Import
+
 ```typescript
 import { NbStat } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `value` | `string` | *required* | The primary metric value displayed prominently. |
-| `label` | `string` | *required* | Descriptive label rendered below (or beside) the value. |
-| `direction` | `'column' \| 'row'` | `'column'` | Stacks value + label vertically or horizontally. |
+
+| Attribute   | Type                | Default    | Description                                             |
+| ----------- | ------------------- | ---------- | ------------------------------------------------------- |
+| `value`     | `string`            | _required_ | The primary metric value displayed prominently.         |
+| `label`     | `string`            | _required_ | Descriptive label rendered below (or beside) the value. |
+| `direction` | `'column' \| 'row'` | `'column'` | Stacks value + label vertically or horizontally.        |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <nb-stat value="$29" label="per month" />
 <nb-stat value="4.8★" label="rating" />
@@ -24,6 +27,7 @@ import { NbStat } from '@ng-brutalism/ui';
 ```
 
 ### With icon
+
 ```html
 <nb-stat value="4.9" label="rating">
   <span slot="icon" aria-hidden="true">★</span>
@@ -31,7 +35,7 @@ import { NbStat } from '@ng-brutalism/ui';
 ```
 
 ### Row direction
+
 ```html
-<nb-stat value="98%" label="satisfaction" direction="row" />
-<nb-stat value="12K" label="downloads" direction="row" />
+<nb-stat value="98%" label="satisfaction" direction="row" /> <nb-stat value="12K" label="downloads" direction="row" />
 ```

--- a/skills/ng-brutalism/references/status-dot.md
+++ b/skills/ng-brutalism/references/status-dot.md
@@ -1,0 +1,31 @@
+# StatusDot
+
+A directive on `<span>` that renders a status indicator dot. Three states — online, offline, and live — cover presence, availability, and real-time streaming use cases.
+
+## Import
+```typescript
+import { NbStatusDot } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `state` | `'online' \| 'offline' \| 'live'` | `'online'` | The visual state of the indicator. |
+| `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | `'md'` | The size of the indicator dot. |
+| `radius` | `NbRadius` | `'md'` | The border radius of the indicator. |
+
+## Usage Examples
+
+### Default
+```html
+<span nbStatusDot state="online"></span>
+<span nbStatusDot state="offline"></span>
+<span nbStatusDot state="live"></span>
+```
+
+### States
+```html
+<span nbStatusDot state="online"></span>
+<span nbStatusDot state="offline"></span>
+<span nbStatusDot state="live"></span>
+```

--- a/skills/ng-brutalism/references/status-dot.md
+++ b/skills/ng-brutalism/references/status-dot.md
@@ -3,20 +3,23 @@
 A directive on `<span>` that renders a status indicator dot. Three states — online, offline, and live — cover presence, availability, and real-time streaming use cases.
 
 ## Import
+
 ```typescript
 import { NbStatusDot } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `state` | `'online' \| 'offline' \| 'live'` | `'online'` | The visual state of the indicator. |
-| `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | `'md'` | The size of the indicator dot. |
-| `radius` | `NbRadius` | `'md'` | The border radius of the indicator. |
+
+| Attribute | Type                              | Default    | Description                         |
+| --------- | --------------------------------- | ---------- | ----------------------------------- |
+| `state`   | `'online' \| 'offline' \| 'live'` | `'online'` | The visual state of the indicator.  |
+| `size`    | `'xs' \| 'sm' \| 'md' \| 'lg'`    | `'md'`     | The size of the indicator dot.      |
+| `radius`  | `NbRadius`                        | `'md'`     | The border radius of the indicator. |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <span nbStatusDot state="online"></span>
 <span nbStatusDot state="offline"></span>
@@ -24,6 +27,7 @@ import { NbStatusDot } from '@ng-brutalism/ui';
 ```
 
 ### States
+
 ```html
 <span nbStatusDot state="online"></span>
 <span nbStatusDot state="offline"></span>

--- a/skills/ng-brutalism/references/sticker.md
+++ b/skills/ng-brutalism/references/sticker.md
@@ -1,0 +1,85 @@
+# Sticker
+
+SVG-backed callout stickers for launches, cards, badges, and decorative bursts. The component auto-scales text inside jagged sticker shapes and includes a small face primitive for the star sticker.
+
+## Import
+```typescript
+import { NbSticker, NbStickerFace } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `shape` | `'burst' \| 'burst-wide' \| 'star' \| 'splat'` | `'burst'` | Outer SVG shape. |
+| `tone` | `'default' \| 'cream' \| 'white' \| 'black' \| 'yellow' \| 'pink' \| 'mint' \| 'lavender' \| 'blue' \| 'primary' \| 'secondary' \| 'accent' \| 'success' \| 'warning' \| 'danger'` | `'mint'` | Background fill token. |
+| `decorative` | `boolean` | `false` | Marks purely visual stickers as hidden from assistive tech. |
+| `rotate` | `number \| undefined` | *shape default* | Optional CSS rotation in degrees. |
+
+## Usage Examples
+
+### Default
+```html
+<nb-sticker shape="burst" tone="mint" [rotate]="-8">
+  NEW<br />
+  JOB!
+</nb-sticker>
+<nb-sticker shape="burst-wide" tone="yellow" [rotate]="5">
+  LIMITED<br />
+  DROP
+</nb-sticker>
+<nb-sticker shape="star" tone="pink" aria-label="Happy sticker">
+  <nb-sticker-face />
+</nb-sticker>
+<nb-sticker shape="splat" tone="blue" decorative />
+```
+
+### Shapes
+```html
+<nb-sticker shape="burst" tone="mint">BURST</nb-sticker>
+<nb-sticker shape="burst-wide" tone="yellow">WIDE</nb-sticker>
+<nb-sticker shape="star" tone="pink" aria-label="Face sticker">
+  <nb-sticker-face />
+</nb-sticker>
+<nb-sticker shape="splat" tone="blue" decorative />
+```
+
+### Tones
+```html
+<nb-sticker class="sticker-tone-face" shape="star" aria-label="Default tone smiling sticker">
+  <nb-sticker-face />
+</nb-sticker>
+<nb-sticker class="sticker-tone-face" shape="star" tone="yellow" aria-label="Yellow smiling sticker">
+  <nb-sticker-face />
+</nb-sticker>
+<nb-sticker class="sticker-tone-face" shape="star" tone="pink" aria-label="Pink smiling sticker">
+  <nb-sticker-face />
+</nb-sticker>
+<nb-sticker class="sticker-tone-face" shape="star" tone="mint" aria-label="Mint smiling sticker">
+  <nb-sticker-face />
+</nb-sticker>
+<nb-sticker class="sticker-tone-face" shape="star" tone="lavender" aria-label="Lavender smiling sticker">
+  <nb-sticker-face />
+</nb-sticker>
+<nb-sticker class="sticker-tone-face" shape="star" tone="blue" aria-label="Blue smiling sticker">
+  <nb-sticker-face />
+</nb-sticker>
+<nb-sticker class="sticker-tone-face" shape="star" tone="accent" aria-label="Accent smiling sticker">
+  <nb-sticker-face />
+</nb-sticker>
+<nb-sticker class="sticker-tone-face" shape="star" tone="success" aria-label="Success smiling sticker">
+  <nb-sticker-face />
+</nb-sticker>
+<nb-sticker class="sticker-tone-face" shape="star" tone="warning" aria-label="Warning smiling sticker">
+  <nb-sticker-face />
+</nb-sticker>
+<nb-sticker class="sticker-tone-face" shape="star" tone="danger" aria-label="Danger smiling sticker">
+  <nb-sticker-face />
+</nb-sticker>
+```
+
+### Rotation
+```html
+<nb-sticker tone="yellow" [rotate]="-12">-12</nb-sticker>
+<nb-sticker tone="pink" [rotate]="0">0</nb-sticker>
+<nb-sticker tone="mint" [rotate]="12">+12</nb-sticker>
+```

--- a/skills/ng-brutalism/references/sticker.md
+++ b/skills/ng-brutalism/references/sticker.md
@@ -3,21 +3,24 @@
 SVG-backed callout stickers for launches, cards, badges, and decorative bursts. The component auto-scales text inside jagged sticker shapes and includes a small face primitive for the star sticker.
 
 ## Import
+
 ```typescript
 import { NbSticker, NbStickerFace } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `shape` | `'burst' \| 'burst-wide' \| 'star' \| 'splat'` | `'burst'` | Outer SVG shape. |
-| `tone` | `'default' \| 'cream' \| 'white' \| 'black' \| 'yellow' \| 'pink' \| 'mint' \| 'lavender' \| 'blue' \| 'primary' \| 'secondary' \| 'accent' \| 'success' \| 'warning' \| 'danger'` | `'mint'` | Background fill token. |
-| `decorative` | `boolean` | `false` | Marks purely visual stickers as hidden from assistive tech. |
-| `rotate` | `number \| undefined` | *shape default* | Optional CSS rotation in degrees. |
+
+| Attribute    | Type                                                                                                                                                                               | Default         | Description                                                 |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ----------------------------------------------------------- |
+| `shape`      | `'burst' \| 'burst-wide' \| 'star' \| 'splat'`                                                                                                                                     | `'burst'`       | Outer SVG shape.                                            |
+| `tone`       | `'default' \| 'cream' \| 'white' \| 'black' \| 'yellow' \| 'pink' \| 'mint' \| 'lavender' \| 'blue' \| 'primary' \| 'secondary' \| 'accent' \| 'success' \| 'warning' \| 'danger'` | `'mint'`        | Background fill token.                                      |
+| `decorative` | `boolean`                                                                                                                                                                          | `false`         | Marks purely visual stickers as hidden from assistive tech. |
+| `rotate`     | `number \| undefined`                                                                                                                                                              | _shape default_ | Optional CSS rotation in degrees.                           |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <nb-sticker shape="burst" tone="mint" [rotate]="-8">
   NEW<br />
@@ -34,6 +37,7 @@ import { NbSticker, NbStickerFace } from '@ng-brutalism/ui';
 ```
 
 ### Shapes
+
 ```html
 <nb-sticker shape="burst" tone="mint">BURST</nb-sticker>
 <nb-sticker shape="burst-wide" tone="yellow">WIDE</nb-sticker>
@@ -44,6 +48,7 @@ import { NbSticker, NbStickerFace } from '@ng-brutalism/ui';
 ```
 
 ### Tones
+
 ```html
 <nb-sticker class="sticker-tone-face" shape="star" aria-label="Default tone smiling sticker">
   <nb-sticker-face />
@@ -78,6 +83,7 @@ import { NbSticker, NbStickerFace } from '@ng-brutalism/ui';
 ```
 
 ### Rotation
+
 ```html
 <nb-sticker tone="yellow" [rotate]="-12">-12</nb-sticker>
 <nb-sticker tone="pink" [rotate]="0">0</nb-sticker>

--- a/skills/ng-brutalism/references/surface-and-section.md
+++ b/skills/ng-brutalism/references/surface-and-section.md
@@ -3,30 +3,35 @@
 `nbSurface` creates the outer brutalist container. `nbSection` creates internal regions. Together they replace repeated card shell markup with a clear, intentional structure.
 
 ## Import
+
 ```typescript
 import { NbSurface, NbSection } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
+
 ### nbSurface
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `tone` | `'cream' \| 'yellow' \| 'pink' \| 'mint' \| 'lavender' \| 'black' \| 'white' \| ...` | - | Color theme |
-| `radius` | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'` | - | Corner shape |
-| `shadow` | `'none' \| 'sm' \| 'default' \| 'hard' \| 'heavy'` | - | Brutalist offset depth |
-| `border` | `'none' \| 'thin' \| 'default' \| 'strong' \| 'thick'` | - | Outline strength |
-| `clip` | `boolean` | `false` | Clips inner content to the surface radius. |
+
+| Attribute | Type                                                                                 | Default | Description                                |
+| --------- | ------------------------------------------------------------------------------------ | ------- | ------------------------------------------ |
+| `tone`    | `'cream' \| 'yellow' \| 'pink' \| 'mint' \| 'lavender' \| 'black' \| 'white' \| ...` | -       | Color theme                                |
+| `radius`  | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'`                           | -       | Corner shape                               |
+| `shadow`  | `'none' \| 'sm' \| 'default' \| 'hard' \| 'heavy'`                                   | -       | Brutalist offset depth                     |
+| `border`  | `'none' \| 'thin' \| 'default' \| 'strong' \| 'thick'`                               | -       | Outline strength                           |
+| `clip`    | `boolean`                                                                            | `false` | Clips inner content to the surface radius. |
 
 ### nbSection
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `padding` | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | - | Internal space |
-| `divider` | `'top' \| 'bottom' \| 'left' \| 'right' \| 'block' \| 'inline' \| 'all' \| 'none'` | - | Divider position |
-| `layout` | `'default' \| 'center' \| 'between'` | - | Flex layout |
+
+| Attribute | Type                                                                               | Default | Description      |
+| --------- | ---------------------------------------------------------------------------------- | ------- | ---------------- |
+| `padding` | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'`                                   | -       | Internal space   |
+| `divider` | `'top' \| 'bottom' \| 'left' \| 'right' \| 'block' \| 'inline' \| 'all' \| 'none'` | -       | Divider position |
+| `layout`  | `'default' \| 'center' \| 'between'`                                               | -       | Flex layout      |
 
 ## Usage Examples
 
 ### Basic Panel
+
 ```html
 <article nbSurface tone="cream" radius="xl" shadow="hard" border="strong" clip>
   <header nbSection padding="lg" divider="bottom">
@@ -40,6 +45,7 @@ import { NbSurface, NbSection } from '@ng-brutalism/ui';
 ```
 
 ### Header / body / footer
+
 ```html
 <article nbSurface tone="yellow" radius="xl" border="thick" shadow="hard" clip>
   <header nbSection padding="lg" divider="bottom">
@@ -51,10 +57,7 @@ import { NbSurface, NbSection } from '@ng-brutalism/ui';
 
   <div nbSection padding="lg">
     <div nbStack gap="md">
-      <p nbText>
-        Body content lives here. Stack controls the vertical
-        rhythm inside the section.
-      </p>
+      <p nbText>Body content lives here. Stack controls the vertical rhythm inside the section.</p>
       <div nbCluster gap="xs">
         <span nbChip tone="mint">Angular</span>
         <span nbChip tone="lavender">Signals</span>
@@ -70,6 +73,7 @@ import { NbSurface, NbSection } from '@ng-brutalism/ui';
 ```
 
 ### Clip
+
 ```html
 <!-- clip keeps inner content within the radius -->
 <article nbSurface tone="cream" radius="xl" shadow="hard" clip class="relative">

--- a/skills/ng-brutalism/references/surface-and-section.md
+++ b/skills/ng-brutalism/references/surface-and-section.md
@@ -1,0 +1,91 @@
+# Surface & Section
+
+`nbSurface` creates the outer brutalist container. `nbSection` creates internal regions. Together they replace repeated card shell markup with a clear, intentional structure.
+
+## Import
+```typescript
+import { NbSurface, NbSection } from '@ng-brutalism/ui';
+```
+
+## API Reference
+### nbSurface
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `tone` | `'cream' \| 'yellow' \| 'pink' \| 'mint' \| 'lavender' \| 'black' \| 'white' \| ...` | - | Color theme |
+| `radius` | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'` | - | Corner shape |
+| `shadow` | `'none' \| 'sm' \| 'default' \| 'hard' \| 'heavy'` | - | Brutalist offset depth |
+| `border` | `'none' \| 'thin' \| 'default' \| 'strong' \| 'thick'` | - | Outline strength |
+| `clip` | `boolean` | `false` | Clips inner content to the surface radius. |
+
+### nbSection
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `padding` | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | - | Internal space |
+| `divider` | `'top' \| 'bottom' \| 'left' \| 'right' \| 'block' \| 'inline' \| 'all' \| 'none'` | - | Divider position |
+| `layout` | `'default' \| 'center' \| 'between'` | - | Flex layout |
+
+## Usage Examples
+
+### Basic Panel
+```html
+<article nbSurface tone="cream" radius="xl" shadow="hard" border="strong" clip>
+  <header nbSection padding="lg" divider="bottom">
+    <h2 nbDisplay size="sm" underline="bar" underlineGap="xs" class="inline-flex flex-col items-start" style="--nb-underline-width: 45%">Profile</h2>
+  </header>
+
+  <div nbSection padding="lg">
+    <p nbText>Chunky card shell with clear regions.</p>
+  </div>
+</article>
+```
+
+### Header / body / footer
+```html
+<article nbSurface tone="yellow" radius="xl" border="thick" shadow="hard" clip>
+  <header nbSection padding="lg" divider="bottom">
+    <div nbCluster gap="sm" align="center" justify="between">
+      <h2 nbDisplay size="sm" underline="bar" underlineGap="xs" class="inline-flex flex-col items-start" style="--nb-underline-width: 45%">Campaign draft</h2>
+      <span nbChip tone="pink">Draft</span>
+    </div>
+  </header>
+
+  <div nbSection padding="lg">
+    <div nbStack gap="md">
+      <p nbText>
+        Body content lives here. Stack controls the vertical
+        rhythm inside the section.
+      </p>
+      <div nbCluster gap="xs">
+        <span nbChip tone="mint">Angular</span>
+        <span nbChip tone="lavender">Signals</span>
+      </div>
+    </div>
+  </div>
+
+  <footer nbSection padding="lg" divider="top" layout="between" align="center">
+    <span nbText tone="muted">Last saved 2m ago</span>
+    <button nbButton tone="black" size="sm">Publish</button>
+  </footer>
+</article>
+```
+
+### Clip
+```html
+<!-- clip keeps inner content within the radius -->
+<article nbSurface tone="cream" radius="xl" shadow="hard" clip class="relative">
+  <header nbSection padding="md" divider="bottom" class="relative bg-(--nb-blue)">
+    <div class="absolute -right-5 -top-5 size-16 rounded-full bg-(--nb-yellow)"></div>
+    <div class="absolute -left-8 bottom-5 h-5 w-36 rotate-[-12deg] bg-(--nb-primary)"></div>
+  </header>
+  <div nbSection padding="md">Decorative children are clipped by the surface.</div>
+</article>
+
+<!-- without clip, the same children can bleed through rounded corners -->
+<article nbSurface tone="cream" radius="xl" shadow="hard" class="relative">
+  <header nbSection padding="md" divider="bottom" class="relative bg-(--nb-blue)">
+    <div class="absolute -right-5 -top-5 size-16 rounded-full bg-(--nb-yellow)"></div>
+    <div class="absolute -left-8 bottom-5 h-5 w-36 rotate-[-12deg] bg-(--nb-primary)"></div>
+  </header>
+  <div nbSection padding="md">Decorative children can spill outside the surface.</div>
+</article>
+```

--- a/skills/ng-brutalism/references/surface.md
+++ b/skills/ng-brutalism/references/surface.md
@@ -3,37 +3,32 @@
 A directive for turning any host element into a brutalist panel. Use `nbSurface` for layout shells, callouts, recipe containers, and custom compositions that need the same borders, tones, radius, and offset shadow system as the packaged components.
 
 ## Import
+
 ```typescript
 import { NbSurface } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `tone` | `'default' \| 'background' \| 'surface' \| 'cream' \| 'white' \| 'black' \| 'yellow' \| 'pink' \| 'mint' \| 'lavender' \| 'blue' \| 'primary' \| 'secondary' \| 'accent' \| 'success' \| 'warning' \| 'danger'` | `'default'` | Background and foreground color pair. |
-| `radius` | `'none' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'` | `'md'` | Corner radius preset. |
-| `border` | `'none' \| 'thin' \| 'default' \| 'strong' \| 'thick'` | `'default'` | Border width preset. |
-| `shadow` | `'none' \| 'sm' \| 'default' \| 'hard' \| 'heavy'` | `'default'` | Offset shadow preset. |
-| `padding` | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'none'` | Uniform inner padding. Prefer `nbSection` for region-specific padding inside a surface. |
-| `size` | `'auto' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'auto'` | Fixed square size. Use for avatar containers or icon-sized surfaces. `'auto'` lets content define the dimensions. |
-| `layout` | `'block' \| 'center' \| 'row' \| 'stack'` | `'block'` | Inner display mode. `center` centers content both axes, `row` aligns children in a row, `stack` stacks them vertically. |
-| `edge` | `'none' \| 'top' \| 'bottom'` | `'none'` | Adds a 2 px accent border on the top or bottom edge using the tone's border color. Useful for callout or notification panels. |
-| `typography` | `'inherit' \| 'body' \| 'display' \| 'accent' \| 'mono'` | `'inherit'` | Sets a font-family role for the surface and all descendant primitives via the cascade. Composes `nbTypography`. |
-| `clip` | `boolean` | `false` | Adds overflow hidden to the surface so child media and decorations respect the surface radius. |
+
+| Attribute    | Type                                                                                                                                                                                                            | Default     | Description                                                                                                                   |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `tone`       | `'default' \| 'background' \| 'surface' \| 'cream' \| 'white' \| 'black' \| 'yellow' \| 'pink' \| 'mint' \| 'lavender' \| 'blue' \| 'primary' \| 'secondary' \| 'accent' \| 'success' \| 'warning' \| 'danger'` | `'default'` | Background and foreground color pair.                                                                                         |
+| `radius`     | `'none' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'`                                                                                                                                                              | `'md'`      | Corner radius preset.                                                                                                         |
+| `border`     | `'none' \| 'thin' \| 'default' \| 'strong' \| 'thick'`                                                                                                                                                          | `'default'` | Border width preset.                                                                                                          |
+| `shadow`     | `'none' \| 'sm' \| 'default' \| 'hard' \| 'heavy'`                                                                                                                                                              | `'default'` | Offset shadow preset.                                                                                                         |
+| `padding`    | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'`                                                                                                                                                                | `'none'`    | Uniform inner padding. Prefer `nbSection` for region-specific padding inside a surface.                                       |
+| `size`       | `'auto' \| 'sm' \| 'md' \| 'lg' \| 'xl'`                                                                                                                                                                        | `'auto'`    | Fixed square size. Use for avatar containers or icon-sized surfaces. `'auto'` lets content define the dimensions.             |
+| `layout`     | `'block' \| 'center' \| 'row' \| 'stack'`                                                                                                                                                                       | `'block'`   | Inner display mode. `center` centers content both axes, `row` aligns children in a row, `stack` stacks them vertically.       |
+| `edge`       | `'none' \| 'top' \| 'bottom'`                                                                                                                                                                                   | `'none'`    | Adds a 2 px accent border on the top or bottom edge using the tone's border color. Useful for callout or notification panels. |
+| `typography` | `'inherit' \| 'body' \| 'display' \| 'accent' \| 'mono'`                                                                                                                                                        | `'inherit'` | Sets a font-family role for the surface and all descendant primitives via the cascade. Composes `nbTypography`.               |
+| `clip`       | `boolean`                                                                                                                                                                                                       | `false`     | Adds overflow hidden to the surface so child media and decorations respect the surface radius.                                |
 
 ## Usage Examples
 
 ### Default
+
 ```html
-<article
-  nbSurface
-  tone="yellow"
-  radius="xl"
-  border="thick"
-  shadow="heavy"
-  clip
-  class="max-w-md"
->
+<article nbSurface tone="yellow" radius="xl" border="thick" shadow="heavy" clip class="max-w-md">
   <div class="border-b-2 border-(--nb-border) bg-nb-primary px-5 py-3">
     <p class="font-mono text-xs font-black uppercase">Launch deck</p>
   </div>
@@ -45,6 +40,7 @@ import { NbSurface } from '@ng-brutalism/ui';
 ```
 
 ### Tones
+
 ```html
 <div nbSurface tone="default">Default theme surface</div>
 <div nbSurface tone="yellow">Yellow surface</div>
@@ -53,6 +49,7 @@ import { NbSurface } from '@ng-brutalism/ui';
 ```
 
 ### Shape
+
 ```html
 <div nbSurface radius="sm" border="thin" shadow="sm">Compact</div>
 <div nbSurface tone="pink" radius="lg" border="default" shadow="hard">Poster</div>
@@ -60,6 +57,7 @@ import { NbSurface } from '@ng-brutalism/ui';
 ```
 
 ### Clip
+
 ```html
 <article nbSurface radius="xl" clip class="relative">
   <div class="relative h-44 bg-(--nb-blue)">

--- a/skills/ng-brutalism/references/surface.md
+++ b/skills/ng-brutalism/references/surface.md
@@ -1,0 +1,71 @@
+# Surface
+
+A directive for turning any host element into a brutalist panel. Use `nbSurface` for layout shells, callouts, recipe containers, and custom compositions that need the same borders, tones, radius, and offset shadow system as the packaged components.
+
+## Import
+```typescript
+import { NbSurface } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `tone` | `'default' \| 'background' \| 'surface' \| 'cream' \| 'white' \| 'black' \| 'yellow' \| 'pink' \| 'mint' \| 'lavender' \| 'blue' \| 'primary' \| 'secondary' \| 'accent' \| 'success' \| 'warning' \| 'danger'` | `'default'` | Background and foreground color pair. |
+| `radius` | `'none' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'` | `'md'` | Corner radius preset. |
+| `border` | `'none' \| 'thin' \| 'default' \| 'strong' \| 'thick'` | `'default'` | Border width preset. |
+| `shadow` | `'none' \| 'sm' \| 'default' \| 'hard' \| 'heavy'` | `'default'` | Offset shadow preset. |
+| `padding` | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'none'` | Uniform inner padding. Prefer `nbSection` for region-specific padding inside a surface. |
+| `size` | `'auto' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'auto'` | Fixed square size. Use for avatar containers or icon-sized surfaces. `'auto'` lets content define the dimensions. |
+| `layout` | `'block' \| 'center' \| 'row' \| 'stack'` | `'block'` | Inner display mode. `center` centers content both axes, `row` aligns children in a row, `stack` stacks them vertically. |
+| `edge` | `'none' \| 'top' \| 'bottom'` | `'none'` | Adds a 2 px accent border on the top or bottom edge using the tone's border color. Useful for callout or notification panels. |
+| `typography` | `'inherit' \| 'body' \| 'display' \| 'accent' \| 'mono'` | `'inherit'` | Sets a font-family role for the surface and all descendant primitives via the cascade. Composes `nbTypography`. |
+| `clip` | `boolean` | `false` | Adds overflow hidden to the surface so child media and decorations respect the surface radius. |
+
+## Usage Examples
+
+### Default
+```html
+<article
+  nbSurface
+  tone="yellow"
+  radius="xl"
+  border="thick"
+  shadow="heavy"
+  clip
+  class="max-w-md"
+>
+  <div class="border-b-2 border-(--nb-border) bg-nb-primary px-5 py-3">
+    <p class="font-mono text-xs font-black uppercase">Launch deck</p>
+  </div>
+  <div class="p-5">
+    <h3>Ship the loud version</h3>
+    <p>Surface gives custom layouts the same brutalist frame.</p>
+  </div>
+</article>
+```
+
+### Tones
+```html
+<div nbSurface tone="default">Default theme surface</div>
+<div nbSurface tone="yellow">Yellow surface</div>
+<div nbSurface tone="black">Black surface</div>
+<div nbSurface tone="success">Success surface</div>
+```
+
+### Shape
+```html
+<div nbSurface radius="sm" border="thin" shadow="sm">Compact</div>
+<div nbSurface tone="pink" radius="lg" border="default" shadow="hard">Poster</div>
+<div nbSurface tone="mint" radius="xl" border="thick" shadow="heavy">Feature</div>
+```
+
+### Clip
+```html
+<article nbSurface radius="xl" clip class="relative">
+  <div class="relative h-44 bg-(--nb-blue)">
+    <div class="absolute -right-10 -top-10 size-28 rounded-full bg-(--nb-yellow)"></div>
+    <div class="absolute -left-12 bottom-8 h-10 w-44 rotate-[-14deg] bg-(--nb-primary)"></div>
+  </div>
+  <div class="p-5">Decorative children stay inside the surface radius.</div>
+</article>
+```

--- a/skills/ng-brutalism/references/text.md
+++ b/skills/ng-brutalism/references/text.md
@@ -1,0 +1,181 @@
+# Text
+
+`nbText` is an attribute directive for general-purpose typography — body copy, labels, brand names, metadata, and captions. It composes cleanly with semantic HTML elements and other primitives without creating a wrapper element.
+
+## Import
+```typescript
+import { NbText } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `size` | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | Font size (0.75 rem – 1.25 rem). |
+| `weight` | `'normal' \| 'medium' \| 'semibold' \| 'bold' \| 'extrabold' \| 'black'` | `'normal'` | Font weight (400 – 900). |
+| `tone` | `'default' \| 'muted' \| 'subtle' \| 'inverse' \| 'primary' \| 'secondary' \| 'accent' \| 'danger' \| 'success' \| 'warning'` | `'default'` | Text color mapped to a design token. |
+| `transform` | `'none' \| 'uppercase' \| 'lowercase' \| 'capitalize'` | `'none'` | CSS text-transform. |
+| `tracking` | `'tight' \| 'normal' \| 'wide' \| 'wider'` | `'normal'` | Letter-spacing (−0.025 em – 0.05 em). |
+| `measure` | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg'` | `'none'` | max-width cap for readable line lengths (20 rem – 44 rem). |
+| `leading` | `'none' \| 'tight' \| 'normal' \| 'relaxed'` | `'normal'` | Line-height override. Defaults to a size-matched value. |
+| `underline` | `'none' \| 'bar' \| 'wave'` | `'none'` | Built-in accent underline beneath the text. Style it with the `--nb-underline-*` tokens. |
+| `reset` | `boolean` | `true` | Sets margin to 0, removing browser paragraph/heading margins so layout primitives own all spacing. |
+
+## Usage Examples
+
+### Default
+```html
+<p nbText>
+  Build loud interfaces with sharp Angular primitives.
+</p>
+```
+
+### Preview
+```html
+<span nbText size="xl" weight="extrabold">Roam &amp; Go</span>
+
+<p nbText size="md" weight="medium" tone="muted" measure="md">
+  Explore iconic neighborhoods, savor local flavors, and make
+  unforgettable memories on every trip.
+</p>
+
+<span nbText size="sm" weight="bold" transform="uppercase" tracking="wide">
+  New release
+</span >
+```
+
+### Sizes
+```html
+<span nbText size="xs">The quick brown fox — 0.75rem</span>
+<span nbText size="sm">The quick brown fox — 0.875rem</span>
+<span nbText size="md">The quick brown fox — 1rem</span>
+<span nbText size="lg">The quick brown fox — 1.125rem</span>
+<span nbText size="xl">The quick brown fox — 1.25rem</span>
+```
+
+### Weights
+```html
+<span nbText size="lg" weight="normal">Build loud. Stay sharp.</span>
+<span nbText size="lg" weight="medium">Build loud. Stay sharp.</span>
+<span nbText size="lg" weight="semibold">Build loud. Stay sharp.</span>
+<span nbText size="lg" weight="bold">Build loud. Stay sharp.</span>
+<span nbText size="lg" weight="extrabold">Build loud. Stay sharp.</span>
+<span nbText size="lg" weight="black">Build loud. Stay sharp.</span>
+```
+
+### Tones
+```html
+<span nbText tone="default">Neo-Brutalism is intentional.</span>
+<span nbText tone="muted">Neo-Brutalism is intentional.</span>
+<span nbText tone="subtle">Neo-Brutalism is intentional.</span>
+<span nbText tone="inverse">Neo-Brutalism is intentional.</span>
+<span nbText tone="primary">Neo-Brutalism is intentional.</span>
+<span nbText tone="secondary">Neo-Brutalism is intentional.</span>
+<span nbText tone="accent">Neo-Brutalism is intentional.</span>
+<span nbText tone="danger">Neo-Brutalism is intentional.</span>
+<span nbText tone="success">Neo-Brutalism is intentional.</span>
+<span nbText tone="warning">Neo-Brutalism is intentional.</span>
+```
+
+### Transform
+```html
+<span nbText weight="bold" transform="none">Flight Included — Tokyo City Escape</span>
+<span nbText weight="bold" transform="uppercase">Flight Included — Tokyo City Escape</span>
+<span nbText weight="bold" transform="lowercase">Flight Included — Tokyo City Escape</span>
+<span nbText weight="bold" transform="capitalize">Flight Included — Tokyo City Escape</span>
+```
+
+### Tracking
+```html
+<span nbText weight="black" transform="uppercase" tracking="tight">New release</span>
+<span nbText weight="black" transform="uppercase" tracking="normal">New release</span>
+<span nbText weight="black" transform="uppercase" tracking="wide">New release</span>
+<span nbText weight="black" transform="uppercase" tracking="wider">New release</span>
+```
+
+### Measure
+```html
+<!-- no cap -->
+<p nbText measure="none">A token-driven neo-brutalist Angular UI library...</p>
+
+<!-- 20rem -->
+<p nbText tone="muted" measure="xs">A token-driven neo-brutalist Angular UI library...</p>
+
+<!-- 28rem -->
+<p nbText tone="muted" measure="sm">A token-driven neo-brutalist Angular UI library...</p>
+
+<!-- 36rem -->
+<p nbText tone="muted" measure="md">A token-driven neo-brutalist Angular UI library...</p>
+
+<!-- 44rem -->
+<p nbText tone="muted" measure="lg">A token-driven neo-brutalist Angular UI library...</p>
+```
+
+### Leading
+```html
+<p nbText size="md" measure="sm" leading="none">...</p>
+<p nbText size="md" measure="sm" leading="tight">...</p>
+<p nbText size="md" measure="sm" leading="normal">...</p>
+<p nbText size="md" measure="sm" leading="relaxed">...</p>
+```
+
+### Underline
+```html
+<span nbText size="3xl" weight="extrabold" underline="bar">
+  Build Loud FM
+</span>
+
+<span nbText size="2xl" weight="extrabold" underline="wave">
+  Stay Sharp
+</span>
+
+<!-- Recolor with a token -->
+<span
+  nbText
+  size="2xl"
+  weight="extrabold"
+  underline="bar"
+  style="--nb-underline-color: var(--nb-mint)"
+>
+  Mint Accent
+</span>
+```
+
+### Composition
+```html
+<div nbStack gap="lg">
+  <div nbStack gap="xs">
+    <span nbText size="xs" weight="bold" transform="uppercase" tracking="wider" tone="muted">
+      Featured deal
+    </span>
+    <h2 nbDisplay>Build loud.</h2>
+  </div>
+
+  <p nbText size="lg" tone="muted" measure="md" leading="relaxed">
+    A token-driven neo-brutalist Angular UI library for expressive
+    product interfaces.
+  </p>
+
+  <div class="flex flex-wrap gap-2">
+    <span nbChip tone="mint">
+      <span nbText size="sm" weight="black" transform="uppercase" tracking="wide">
+        Flight included
+      </span>
+    </span>
+    <span nbChip tone="lavender">
+      <span nbText size="sm" weight="black" transform="uppercase" tracking="wide">
+        Hotel
+      </span>
+    </span>
+  </div>
+
+  <div nbCallout tone="yellow" size="lg" layout="between" shadow="hard">
+    <div nbStack gap="none">
+      <span nbText size="xs" weight="bold" transform="uppercase" tracking="wider" tone="muted">
+        From
+      </span>
+      <span nbText size="xl" weight="black">$799</span>
+    </div>
+    <span nbText size="sm" weight="medium">per person</span>
+  </div>
+</div>
+```

--- a/skills/ng-brutalism/references/text.md
+++ b/skills/ng-brutalism/references/text.md
@@ -3,47 +3,45 @@
 `nbText` is an attribute directive for general-purpose typography — body copy, labels, brand names, metadata, and captions. It composes cleanly with semantic HTML elements and other primitives without creating a wrapper element.
 
 ## Import
+
 ```typescript
 import { NbText } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `size` | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | Font size (0.75 rem – 1.25 rem). |
-| `weight` | `'normal' \| 'medium' \| 'semibold' \| 'bold' \| 'extrabold' \| 'black'` | `'normal'` | Font weight (400 – 900). |
-| `tone` | `'default' \| 'muted' \| 'subtle' \| 'inverse' \| 'primary' \| 'secondary' \| 'accent' \| 'danger' \| 'success' \| 'warning'` | `'default'` | Text color mapped to a design token. |
-| `transform` | `'none' \| 'uppercase' \| 'lowercase' \| 'capitalize'` | `'none'` | CSS text-transform. |
-| `tracking` | `'tight' \| 'normal' \| 'wide' \| 'wider'` | `'normal'` | Letter-spacing (−0.025 em – 0.05 em). |
-| `measure` | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg'` | `'none'` | max-width cap for readable line lengths (20 rem – 44 rem). |
-| `leading` | `'none' \| 'tight' \| 'normal' \| 'relaxed'` | `'normal'` | Line-height override. Defaults to a size-matched value. |
-| `underline` | `'none' \| 'bar' \| 'wave'` | `'none'` | Built-in accent underline beneath the text. Style it with the `--nb-underline-*` tokens. |
-| `reset` | `boolean` | `true` | Sets margin to 0, removing browser paragraph/heading margins so layout primitives own all spacing. |
+
+| Attribute   | Type                                                                                                                          | Default     | Description                                                                                        |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------- | ----------- | -------------------------------------------------------------------------------------------------- |
+| `size`      | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'`                                                                                        | `'md'`      | Font size (0.75 rem – 1.25 rem).                                                                   |
+| `weight`    | `'normal' \| 'medium' \| 'semibold' \| 'bold' \| 'extrabold' \| 'black'`                                                      | `'normal'`  | Font weight (400 – 900).                                                                           |
+| `tone`      | `'default' \| 'muted' \| 'subtle' \| 'inverse' \| 'primary' \| 'secondary' \| 'accent' \| 'danger' \| 'success' \| 'warning'` | `'default'` | Text color mapped to a design token.                                                               |
+| `transform` | `'none' \| 'uppercase' \| 'lowercase' \| 'capitalize'`                                                                        | `'none'`    | CSS text-transform.                                                                                |
+| `tracking`  | `'tight' \| 'normal' \| 'wide' \| 'wider'`                                                                                    | `'normal'`  | Letter-spacing (−0.025 em – 0.05 em).                                                              |
+| `measure`   | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg'`                                                                                      | `'none'`    | max-width cap for readable line lengths (20 rem – 44 rem).                                         |
+| `leading`   | `'none' \| 'tight' \| 'normal' \| 'relaxed'`                                                                                  | `'normal'`  | Line-height override. Defaults to a size-matched value.                                            |
+| `underline` | `'none' \| 'bar' \| 'wave'`                                                                                                   | `'none'`    | Built-in accent underline beneath the text. Style it with the `--nb-underline-*` tokens.           |
+| `reset`     | `boolean`                                                                                                                     | `true`      | Sets margin to 0, removing browser paragraph/heading margins so layout primitives own all spacing. |
 
 ## Usage Examples
 
 ### Default
+
 ```html
-<p nbText>
-  Build loud interfaces with sharp Angular primitives.
-</p>
+<p nbText>Build loud interfaces with sharp Angular primitives.</p>
 ```
 
 ### Preview
+
 ```html
 <span nbText size="xl" weight="extrabold">Roam &amp; Go</span>
 
-<p nbText size="md" weight="medium" tone="muted" measure="md">
-  Explore iconic neighborhoods, savor local flavors, and make
-  unforgettable memories on every trip.
-</p>
+<p nbText size="md" weight="medium" tone="muted" measure="md">Explore iconic neighborhoods, savor local flavors, and make unforgettable memories on every trip.</p>
 
-<span nbText size="sm" weight="bold" transform="uppercase" tracking="wide">
-  New release
-</span >
+<span nbText size="sm" weight="bold" transform="uppercase" tracking="wide"> New release </span>
 ```
 
 ### Sizes
+
 ```html
 <span nbText size="xs">The quick brown fox — 0.75rem</span>
 <span nbText size="sm">The quick brown fox — 0.875rem</span>
@@ -53,6 +51,7 @@ import { NbText } from '@ng-brutalism/ui';
 ```
 
 ### Weights
+
 ```html
 <span nbText size="lg" weight="normal">Build loud. Stay sharp.</span>
 <span nbText size="lg" weight="medium">Build loud. Stay sharp.</span>
@@ -63,6 +62,7 @@ import { NbText } from '@ng-brutalism/ui';
 ```
 
 ### Tones
+
 ```html
 <span nbText tone="default">Neo-Brutalism is intentional.</span>
 <span nbText tone="muted">Neo-Brutalism is intentional.</span>
@@ -77,6 +77,7 @@ import { NbText } from '@ng-brutalism/ui';
 ```
 
 ### Transform
+
 ```html
 <span nbText weight="bold" transform="none">Flight Included — Tokyo City Escape</span>
 <span nbText weight="bold" transform="uppercase">Flight Included — Tokyo City Escape</span>
@@ -85,6 +86,7 @@ import { NbText } from '@ng-brutalism/ui';
 ```
 
 ### Tracking
+
 ```html
 <span nbText weight="black" transform="uppercase" tracking="tight">New release</span>
 <span nbText weight="black" transform="uppercase" tracking="normal">New release</span>
@@ -93,6 +95,7 @@ import { NbText } from '@ng-brutalism/ui';
 ```
 
 ### Measure
+
 ```html
 <!-- no cap -->
 <p nbText measure="none">A token-driven neo-brutalist Angular UI library...</p>
@@ -111,6 +114,7 @@ import { NbText } from '@ng-brutalism/ui';
 ```
 
 ### Leading
+
 ```html
 <p nbText size="md" measure="sm" leading="none">...</p>
 <p nbText size="md" measure="sm" leading="tight">...</p>
@@ -119,60 +123,39 @@ import { NbText } from '@ng-brutalism/ui';
 ```
 
 ### Underline
-```html
-<span nbText size="3xl" weight="extrabold" underline="bar">
-  Build Loud FM
-</span>
 
-<span nbText size="2xl" weight="extrabold" underline="wave">
-  Stay Sharp
-</span>
+```html
+<span nbText size="3xl" weight="extrabold" underline="bar"> Build Loud FM </span>
+
+<span nbText size="2xl" weight="extrabold" underline="wave"> Stay Sharp </span>
 
 <!-- Recolor with a token -->
-<span
-  nbText
-  size="2xl"
-  weight="extrabold"
-  underline="bar"
-  style="--nb-underline-color: var(--nb-mint)"
->
-  Mint Accent
-</span>
+<span nbText size="2xl" weight="extrabold" underline="bar" style="--nb-underline-color: var(--nb-mint)"> Mint Accent </span>
 ```
 
 ### Composition
+
 ```html
 <div nbStack gap="lg">
   <div nbStack gap="xs">
-    <span nbText size="xs" weight="bold" transform="uppercase" tracking="wider" tone="muted">
-      Featured deal
-    </span>
+    <span nbText size="xs" weight="bold" transform="uppercase" tracking="wider" tone="muted"> Featured deal </span>
     <h2 nbDisplay>Build loud.</h2>
   </div>
 
-  <p nbText size="lg" tone="muted" measure="md" leading="relaxed">
-    A token-driven neo-brutalist Angular UI library for expressive
-    product interfaces.
-  </p>
+  <p nbText size="lg" tone="muted" measure="md" leading="relaxed">A token-driven neo-brutalist Angular UI library for expressive product interfaces.</p>
 
   <div class="flex flex-wrap gap-2">
     <span nbChip tone="mint">
-      <span nbText size="sm" weight="black" transform="uppercase" tracking="wide">
-        Flight included
-      </span>
+      <span nbText size="sm" weight="black" transform="uppercase" tracking="wide"> Flight included </span>
     </span>
     <span nbChip tone="lavender">
-      <span nbText size="sm" weight="black" transform="uppercase" tracking="wide">
-        Hotel
-      </span>
+      <span nbText size="sm" weight="black" transform="uppercase" tracking="wide"> Hotel </span>
     </span>
   </div>
 
   <div nbCallout tone="yellow" size="lg" layout="between" shadow="hard">
     <div nbStack gap="none">
-      <span nbText size="xs" weight="bold" transform="uppercase" tracking="wider" tone="muted">
-        From
-      </span>
+      <span nbText size="xs" weight="bold" transform="uppercase" tracking="wider" tone="muted"> From </span>
       <span nbText size="xl" weight="black">$799</span>
     </div>
     <span nbText size="sm" weight="medium">per person</span>

--- a/skills/ng-brutalism/references/textarea.md
+++ b/skills/ng-brutalism/references/textarea.md
@@ -1,0 +1,42 @@
+# Textarea
+
+The neo-brutalist Angular Textarea component. A multi-line text input with hard borders, offset shadow, and strong focus states matching the brutalist style.
+
+## Import
+```typescript
+import { NbTextarea } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | The size of the textarea input. |
+
+## Usage Examples
+
+### Default
+```html
+<textarea nbTextarea placeholder="Write something..." class="w-75"></textarea>
+```
+
+### Sizes
+```html
+<div class="flex flex-col items-center gap-4">
+  <textarea nbTextarea size="sm" placeholder="Small" class="w-75"></textarea>
+  <textarea nbTextarea placeholder="Default" class="w-75"></textarea>
+  <textarea nbTextarea size="lg" placeholder="Large" class="w-75"></textarea>
+</div>
+```
+
+### Disabled
+```html
+<textarea nbTextarea placeholder="Disabled" class="w-75" disabled></textarea>
+```
+
+### With Label
+```html
+<div class="flex flex-col gap-2">
+  <label nbLabel for="message">Message</label>
+  <textarea nbTextarea id="message" placeholder="Enter your message..." class="w-75"></textarea>
+</div>
+```

--- a/skills/ng-brutalism/references/textarea.md
+++ b/skills/ng-brutalism/references/textarea.md
@@ -3,23 +3,27 @@
 The neo-brutalist Angular Textarea component. A multi-line text input with hard borders, offset shadow, and strong focus states matching the brutalist style.
 
 ## Import
+
 ```typescript
 import { NbTextarea } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | The size of the textarea input. |
+
+| Attribute | Type                   | Default | Description                     |
+| --------- | ---------------------- | ------- | ------------------------------- |
+| `size`    | `'sm' \| 'md' \| 'lg'` | `'md'`  | The size of the textarea input. |
 
 ## Usage Examples
 
 ### Default
+
 ```html
 <textarea nbTextarea placeholder="Write something..." class="w-75"></textarea>
 ```
 
 ### Sizes
+
 ```html
 <div class="flex flex-col items-center gap-4">
   <textarea nbTextarea size="sm" placeholder="Small" class="w-75"></textarea>
@@ -29,11 +33,13 @@ import { NbTextarea } from '@ng-brutalism/ui';
 ```
 
 ### Disabled
+
 ```html
 <textarea nbTextarea placeholder="Disabled" class="w-75" disabled></textarea>
 ```
 
 ### With Label
+
 ```html
 <div class="flex flex-col gap-2">
   <label nbLabel for="message">Message</label>

--- a/skills/ng-brutalism/references/title.md
+++ b/skills/ng-brutalism/references/title.md
@@ -3,46 +3,37 @@
 The neo-brutalist Angular Title component. Adds a brutalist wave underline to headings without changing the heading level or document structure.
 
 ## Import
+
 ```typescript
 import { NbTitle } from '@ng-brutalism/ui';
 ```
 
 ## API Reference
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `[nbTitle]` | `Directive` | - | Applies `data-nb-title` and draws a configurable wave underline with a CSS pseudo element. |
+
+| Attribute   | Type        | Default | Description                                                                                |
+| ----------- | ----------- | ------- | ------------------------------------------------------------------------------------------ |
+| `[nbTitle]` | `Directive` | -       | Applies `data-nb-title` and draws a configurable wave underline with a CSS pseudo element. |
 
 ## Usage Examples
 
 ### Default
+
 ```html
-<h2 nbTitle class="font-mono text-4xl font-black leading-tight uppercase">
-  Brutal section title
-</h2>
+<h2 nbTitle class="font-mono text-4xl font-black leading-tight uppercase">Brutal section title</h2>
 ```
 
 ### Custom Wave
+
 ```html
-<h3
-  nbTitle
-  class="font-mono text-3xl font-black leading-tight"
-  style="--nb-title-wave-color: #ff5d8f; --nb-title-wave-width: 12rem; --nb-title-wave-height: 0.75rem;"
->
-  Sharp editorial heading
-</h3>
+<h3 nbTitle class="font-mono text-3xl font-black leading-tight" style="--nb-title-wave-color: #ff5d8f; --nb-title-wave-width: 12rem; --nb-title-wave-height: 0.75rem;">Sharp editorial heading</h3>
 ```
 
 ### Mixed Content
+
 ```html
 <div class="max-w-xl border-2 border-(--nb-border) bg-nb-surface p-6 shadow-[5px_5px_0_0_var(--nb-shadow)]">
-  <p class="mb-3 inline-block border-2 border-(--nb-border) bg-nb-secondary px-3 py-1 font-mono text-xs font-black uppercase">
-    Release notes
-  </p>
-  <h2 nbTitle class="font-mono text-4xl font-black leading-tight">
-    Fast primitives, loud defaults
-  </h2>
-  <p class="mt-5 font-medium">
-    Use it with your own typography classes, then tune the underline with CSS variables when a title needs more attitude.
-  </p>
+  <p class="mb-3 inline-block border-2 border-(--nb-border) bg-nb-secondary px-3 py-1 font-mono text-xs font-black uppercase">Release notes</p>
+  <h2 nbTitle class="font-mono text-4xl font-black leading-tight">Fast primitives, loud defaults</h2>
+  <p class="mt-5 font-medium">Use it with your own typography classes, then tune the underline with CSS variables when a title needs more attitude.</p>
 </div>
 ```

--- a/skills/ng-brutalism/references/title.md
+++ b/skills/ng-brutalism/references/title.md
@@ -1,0 +1,48 @@
+# Title
+
+The neo-brutalist Angular Title component. Adds a brutalist wave underline to headings without changing the heading level or document structure.
+
+## Import
+```typescript
+import { NbTitle } from '@ng-brutalism/ui';
+```
+
+## API Reference
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `[nbTitle]` | `Directive` | - | Applies `data-nb-title` and draws a configurable wave underline with a CSS pseudo element. |
+
+## Usage Examples
+
+### Default
+```html
+<h2 nbTitle class="font-mono text-4xl font-black leading-tight uppercase">
+  Brutal section title
+</h2>
+```
+
+### Custom Wave
+```html
+<h3
+  nbTitle
+  class="font-mono text-3xl font-black leading-tight"
+  style="--nb-title-wave-color: #ff5d8f; --nb-title-wave-width: 12rem; --nb-title-wave-height: 0.75rem;"
+>
+  Sharp editorial heading
+</h3>
+```
+
+### Mixed Content
+```html
+<div class="max-w-xl border-2 border-(--nb-border) bg-nb-surface p-6 shadow-[5px_5px_0_0_var(--nb-shadow)]">
+  <p class="mb-3 inline-block border-2 border-(--nb-border) bg-nb-secondary px-3 py-1 font-mono text-xs font-black uppercase">
+    Release notes
+  </p>
+  <h2 nbTitle class="font-mono text-4xl font-black leading-tight">
+    Fast primitives, loud defaults
+  </h2>
+  <p class="mt-5 font-medium">
+    Use it with your own typography classes, then tune the underline with CSS variables when a title needs more attitude.
+  </p>
+</div>
+```


### PR DESCRIPTION
- Added skills/ng-brutalism/SKILL.md defining the neo-brutalist Angular UI mental model and composition rules.
- Added comprehensive component and layout reference documentation under skills/ng-brutalism/references/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
- **Expanded ng-brutalism UI Library Guides** – Added a new skill documentation page with a “progressive disclosure” approach, core composition mental model, and standardized token vocabulary for consistent styling.
- **Component Reference Pages** – Added detailed API reference and copy-paste usage examples for many Angular UI components and primitives (e.g., layout primitives, form controls, typography, feedback, and media elements), plus an overview and common patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->